### PR TITLE
Fixed error on documentation of fLit in Fixed.hs

### DIFF
--- a/src/CLaSH/Sized/Fixed.hs
+++ b/src/CLaSH/Sized/Fixed.hs
@@ -494,7 +494,7 @@ satN2 rep = if isSigned rep
 --
 -- So when you type:
 --
--- > n = $$(fLit 2.2867) :: SFixed 4 4
+-- > n = $$(fLit 2.8672) :: SFixed 4 4
 --
 -- The compiler sees:
 --


### PR DESCRIPTION
The example in the documentation of fLit contains an error. The number '2.2867' does not correpond to 'Integer 45' (which leads indeed to '2.8125'), but it corresponds to 'Integer 36' (which leads to '2.25').

There are several ways to fix this, I decided to move the second '2' in '2.2867' to the end.
