### PR TITLE
WIP: Clock Lines in Haskell

### DIFF
--- a/clash-prelude.cabal
+++ b/clash-prelude.cabal
@@ -149,6 +149,7 @@ Library
                       TypeFamilies
                       TypeOperators
                       UndecidableInstances
+                      ImplicitParams
 
   Build-depends:      array                     >= 0.5.1.0,
                       base                      >= 4.8.0.0 && < 5,

--- a/clash-prelude.cabal
+++ b/clash-prelude.cabal
@@ -93,6 +93,7 @@ Library
                       CLaSH.Prelude.DataFlow
                       CLaSH.Prelude.Explicit
                       CLaSH.Prelude.Explicit.Safe
+                      CLaSH.Prelude.ElimClocks
                       CLaSH.Prelude.Mealy
                       CLaSH.Prelude.Moore
                       CLaSH.Prelude.RAM

--- a/src/CLaSH/Prelude.hs
+++ b/src/CLaSH/Prelude.hs
@@ -142,7 +142,7 @@ import CLaSH.Prelude.BitIndex
 import CLaSH.Prelude.BitReduction
 import CLaSH.Prelude.BlockRam.File (blockRamFile, blockRamFilePow2)
 import CLaSH.Prelude.DataFlow
-import CLaSH.Prelude.Explicit      (window', windowD')
+import CLaSH.Prelude.Explicit      (window, windowD)
 import CLaSH.Prelude.ROM.File      (asyncRomFile,asyncRomFilePow2,romFile,
                                     romFilePow2)
 import CLaSH.Prelude.Safe
@@ -177,29 +177,3 @@ splitAt, tail, take, unzip, unzip3, zip, zip3, zipWith, zipWith3.
 It instead exports the identically named functions defined in terms of
 'CLaSH.Sized.Vector.Vec' at "CLaSH.Sized.Vector".
 -}
-
-{-# INLINE window #-}
--- | Give a window over a 'Signal'
---
--- > window4 :: Signal Int -> Vec 4 (Signal Int)
--- > window4 = window
---
--- >>> simulateB window4 [1::Int,2,3,4,5] :: [Vec 4 Int]
--- [<1,0,0,0>,<2,1,0,0>,<3,2,1,0>,<4,3,2,1>,<5,4,3,2>...
-window :: (KnownNat n, Default a)
-       => Signal a                -- ^ Signal to create a window over
-       -> Vec (n + 1) (Signal a)  -- ^ Window of at least size 1
-window = window' systemClock
-
-{-# INLINE windowD #-}
--- | Give a delayed window over a 'Signal'
---
--- > windowD3 :: Signal Int -> Vec 3 (Signal Int)
--- > windowD3 = windowD
---
--- >>> simulateB windowD3 [1::Int,2,3,4] :: [Vec 3 Int]
--- [<0,0,0>,<1,0,0>,<2,1,0>,<3,2,1>,<4,3,2>...
-windowD :: (KnownNat (n + 1), Default a)
-        => Signal a               -- ^ Signal to create a window over
-        -> Vec (n + 1) (Signal a) -- ^ Window of at least size 1
-windowD = windowD' systemClock

--- a/src/CLaSH/Prelude/DataFlow.hs
+++ b/src/CLaSH/Prelude/DataFlow.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ImplicitParams        #-}
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -41,7 +42,7 @@ import GHC.TypeLits          (KnownNat, KnownSymbol)
 
 import CLaSH.Signal          ((.&&.), regEn, unbundle)
 import CLaSH.Signal.Bundle   (Bundle (..))
-import CLaSH.Signal.Explicit (Clock (..), Signal', SystemClock, sclock)
+import CLaSH.Signal.Explicit (SClock, Clock (..), Signal', SystemClock, sclock)
 
 {- | Dataflow circuit with bidirectional synchronisation channels.
 
@@ -124,7 +125,8 @@ liftDF = DF
 
 -- | Create a 'DataFlow' circuit from a Mealy machine description as those of
 -- "CLaSH.Prelude.Mealy"
-mealyDF :: (s -> i -> (s,o))
+mealyDF :: (?clk :: SClock SystemClock)
+        => (s -> i -> (s,o))
         -> s
         -> DataFlow Bool Bool i o
 mealyDF f iS = DF (\i iV oR -> let en     = iV .&&. oR
@@ -134,7 +136,8 @@ mealyDF f iS = DF (\i iV oR -> let en     = iV .&&. oR
 
 -- | Create a 'DataFlow' circuit from a Moore machine description as those of
 -- "CLaSH.Prelude.Moore"
-mooreDF :: (s -> i -> s)
+mooreDF :: (?clk :: SClock SystemClock)
+        => (s -> i -> s)
         -> (s -> o)
         -> s
         -> DataFlow Bool Bool i o

--- a/src/CLaSH/Prelude/ElimClocks.hs
+++ b/src/CLaSH/Prelude/ElimClocks.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeFamilies #-}
+module CLaSH.Prelude.ElimClocks where
+
+import GHC.TypeLits          (KnownNat, KnownSymbol)
+
+import CLaSH.Signal.Explicit (SClock, Clock(..), sclock)
+
+type family ElimClocks a where
+  ElimClocks (SClock ('Clk s p) -> a) = ElimClocks a
+  ElimClocks (b                 -> a) = b -> ElimClocks a
+  ElimClocks a                        = a
+
+class ElimClocks a ~ b => NeedsClocks a b where
+  -- | Fill in clock-line arguments, for easy use on the REPL
+  --
+  -- The clock-line arguments are used by the CLaSH compiler to infer the proper
+  -- nets, but don't actually matter for simulation in Haskell. This function
+  -- just fills them in with dummy arguments, as there is no "real" clock to
+  -- connect them to.
+  --
+  -- >>> :{
+  -- let g :: SClock ('Clk "asdf" 100)
+  --       -> Int
+  --       -> SClock ('Clk "qwer" 99)
+  --       -> Int
+  --     g _ i _ = i
+  -- :}
+  -- >>> :{
+  -- let f :: Int -> Int
+  --     f = provideClocks g
+  -- :}
+  --
+  -- __NB__: This function is not synthesisable
+  provideClocks :: a -> b
+
+instance (KnownNat p, KnownSymbol s, NeedsClocks a b)
+    => NeedsClocks (SClock ('Clk s p) -> a) b where
+  provideClocks f = provideClocks $ f sclock
+
+instance (NeedsClocks a c, ElimClocks (b -> a) ~ (b -> ElimClocks a))
+    => NeedsClocks (b -> a) (b -> c) where
+  provideClocks f = \b -> provideClocks $ f b
+
+instance a ~ ElimClocks a
+    => NeedsClocks a a where
+  provideClocks = id

--- a/src/CLaSH/Prelude/Mealy.hs
+++ b/src/CLaSH/Prelude/Mealy.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE ImplicitParams #-}
+
 {-# LANGUAGE Safe #-}
 
 {-|
@@ -12,18 +14,14 @@
   requirements.
 -}
 module CLaSH.Prelude.Mealy
-  ( -- * Mealy machine synchronised to the system clock
+  ( -- * Mealy machine synchronised to an arbitrary clock
     mealy
   , mealyB
   , (<^>)
-    -- * Mealy machine synchronised to an arbitrary clock
-  , mealy'
-  , mealyB'
   )
 where
 
-import CLaSH.Signal          (Signal, Unbundled)
-import CLaSH.Signal.Explicit (Signal', SClock, register', systemClock)
+import CLaSH.Signal.Explicit (Signal', SClock, register)
 import CLaSH.Signal.Bundle   (Bundle (..), Unbundled')
 
 {- $setup
@@ -48,93 +46,7 @@ let mac s (x,y) = (s',s)
 >>> let topEntity = mealy' clkA mac 0
 -}
 
-{-# INLINE mealy #-}
--- | Create a synchronous function from a combinational function describing
--- a mealy machine
---
--- @
--- mac :: Int        -- Current state
---     -> (Int,Int)  -- Input
---     -> (Int,Int)  -- (Updated state, output)
--- mac s (x,y) = (s',s)
---   where
---     s' = x * y + s
---
--- topEntity :: 'Signal' (Int, Int) -> 'Signal' Int
--- topEntity = 'mealy' mac 0
--- @
---
--- >>> simulate topEntity [(1,1),(2,2),(3,3),(4,4)]
--- [0,1,5,14...
---
--- Synchronous sequential functions can be composed just like their
--- combinational counterpart:
---
--- @
--- dualMac :: ('Signal' Int, 'Signal' Int)
---         -> ('Signal' Int, 'Signal' Int)
---         -> 'Signal' Int
--- dualMac (a,b) (x,y) = s1 + s2
---   where
---     s1 = 'mealy' mac 0 ('CLaSH.Signal.bundle' (a,x))
---     s2 = 'mealy' mac 0 ('CLaSH.Signal.bundle' (b,y))
--- @
-mealy :: (s -> i -> (s,o)) -- ^ Transfer function in mealy machine form:
-                           -- @state -> input -> (newstate,output)@
-      -> s                 -- ^ Initial state
-      -> (Signal i -> Signal o)
-      -- ^ Synchronous sequential function with input and output matching that
-      -- of the mealy machine
-mealy = mealy' systemClock
-
-{-# INLINE mealyB #-}
--- | A version of 'mealy' that does automatic 'Bundle'ing
---
--- Given a function @f@ of type:
---
--- @
--- __f__ :: Int -> (Bool, Int) -> (Int, (Int, Bool))
--- @
---
--- When we want to make compositions of @f@ in @g@ using 'mealy', we have to
--- write:
---
--- @
--- g a b c = (b1,b2,i2)
---   where
---     (i1,b1) = 'CLaSH.Signal.unbundle' ('mealy' f 0 ('CLaSH.Signal.bundle' (a,b)))
---     (i2,b2) = 'CLaSH.Signal.unbundle' ('mealy' f 3 ('CLaSH.Signal.bundle' (i1,c)))
--- @
---
--- Using 'mealyB' however we can write:
---
--- @
--- g a b c = (b1,b2,i2)
---   where
---     (i1,b1) = 'mealyB' f 0 (a,b)
---     (i2,b2) = 'mealyB' f 3 (i1,c)
--- @
-mealyB :: (Bundle i, Bundle o)
-       => (s -> i -> (s,o)) -- ^ Transfer function in mealy machine form:
-                            -- @state -> input -> (newstate,output)@
-       -> s                 -- ^ Initial state
-       -> (Unbundled i -> Unbundled o)
-       -- ^ Synchronous sequential function with input and output matching that
-       -- of the mealy machine
-mealyB = mealyB' systemClock
-
-{-# INLINE (<^>) #-}
--- | Infix version of 'mealyB'
-(<^>) :: (Bundle i, Bundle o)
-      => (s -> i -> (s,o)) -- ^ Transfer function in mealy machine form:
-                           -- @state -> input -> (newstate,output)@
-      -> s                 -- ^ Initial state
-      -> (Unbundled i -> Unbundled o)
-      -- ^ Synchronous sequential function with input and output matching that
-      -- of the mealy machine
-(<^>) = mealyB
-
-{-# INLINABLE mealy' #-}
+{-# INLINABLE mealy #-}
 -- | Create a synchronous function from a combinational function describing
 -- a mealy machine
 --
@@ -158,6 +70,14 @@ mealyB = mealyB' systemClock
 -- >>> simulate topEntity [(1,1),(2,2),(3,3),(4,4)]
 -- [0,1,5,14...
 --
+-- @
+-- topEntity :: 'Signal' (Int, Int) -> 'Signal' Int
+-- topEntity = 'mealy' mac 0
+-- @
+--
+-- >>> simulate topEntity [(1,1),(2,2),(3,3),(4,4)]
+-- [0,1,5,14...
+--
 -- Synchronous sequential functions can be composed just like their
 -- combinational counterpart:
 --
@@ -170,18 +90,18 @@ mealyB = mealyB' systemClock
 --     s1 = 'mealy'' clkA100 mac 0 ('CLaSH.Signal.Explicit.bundle'' clkA100 (a,x))
 --     s2 = 'mealy'' clkA100 mac 0 ('CLaSH.Signal.Explicit.bundle'' clkA100 (b,y))
 -- @
-mealy' :: SClock clk        -- ^ 'Clock' to synchronize to
-       -> (s -> i -> (s,o)) -- ^ Transfer function in mealy machine form:
-                            -- @state -> input -> (newstate,output)@
-       -> s                 -- ^ Initial state
-       -> (Signal' clk i -> Signal' clk o)
-       -- ^ Synchronous sequential function with input and output matching that
-       -- of the mealy machine
-mealy' clk f iS = \i -> let (s',o) = unbundle' clk $ f <$> s <*> i
-                            s      = register' clk iS s'
-                        in  o
+mealy :: (?clk :: SClock clk) -- ^ 'Clock' to synchronize to
+      => (s -> i -> (s,o))    -- ^ Transfer function in mealy machine form:
+                              -- @state -> input -> (newstate,output)@
+      -> s                    -- ^ Initial state
+      -> (Signal' clk i -> Signal' clk o)
+      -- ^ Synchronous sequential function with input and output matching that
+      -- of the mealy machine
+mealy f iS = \i -> let (s',o) = unbundle' ?clk $ f <$> s <*> i
+                       s      = register iS s'
+                   in  o
 
-{-# INLINE mealyB' #-}
+{-# INLINE mealyB #-}
 -- | A version of 'mealy'' that does automatic 'Bundle'ing
 --
 -- Given a function @f@ of type:
@@ -208,12 +128,24 @@ mealy' clk f iS = \i -> let (s',o) = unbundle' clk $ f <$> s <*> i
 --     (i1,b1) = 'mealyB'' clk f 0 (a,b)
 --     (i2,b2) = 'mealyB'' clk f 3 (i1,c)
 -- @
-mealyB' :: (Bundle i, Bundle o)
-        => SClock clk
-        -> (s -> i -> (s,o)) -- ^ Transfer function in mealy machine form:
-                     -- @state -> input -> (newstate,output)@
-        -> s                 -- ^ Initial state
-        -> (Unbundled' clk i -> Unbundled' clk o)
-        -- ^ Synchronous sequential function with input and output matching that
-        -- of the mealy machine
-mealyB' clk f iS i = unbundle' clk (mealy' clk f iS (bundle' clk i))
+mealyB :: (Bundle i, Bundle o)
+       => (?clk :: SClock clk) -- ^ 'Clock' to synchronize to
+       => (s -> i -> (s,o))    -- ^ Transfer function in mealy machine form:
+                               -- @state -> input -> (newstate,output)@
+       -> s                    -- ^ Initial state
+       -> (Unbundled' clk i -> Unbundled' clk o)
+       -- ^ Synchronous sequential function with input and output matching that
+       -- of the mealy machine
+mealyB f iS i = unbundle' ?clk (mealy f iS (bundle' ?clk i))
+
+{-# INLINE (<^>) #-}
+-- | Infix version of 'mealyB'
+(<^>) :: (Bundle i, Bundle o)
+      => (?clk :: SClock clk) -- ^ 'Clock' to synchronize to
+      => (s -> i -> (s,o))    -- ^ Transfer function in mealy machine form:
+                              -- @state -> input -> (newstate,output)@
+      -> s                    -- ^ Initial state
+      -> (Unbundled' clk i -> Unbundled' clk o)
+      -- ^ Synchronous sequential function with input and output matching that
+      -- of the mealy machine
+(<^>) = mealyB

--- a/src/CLaSH/Prelude/Moore.hs
+++ b/src/CLaSH/Prelude/Moore.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE ImplicitParams #-}
+
 {-# LANGUAGE Safe #-}
 
 {-|
@@ -12,17 +14,13 @@
   requirements.
 -}
 module CLaSH.Prelude.Moore
-  ( -- * Moore machine synchronised to the system clock
+  ( -- * Moore machine synchronised to an arbitrary clock
     moore
   , mooreB
-    -- * Moore machine synchronised to an arbitrary clock
-  , moore'
-  , mooreB'
   )
 where
 
-import CLaSH.Signal          (Signal, Unbundled)
-import CLaSH.Signal.Explicit (Signal', SClock, register', systemClock)
+import CLaSH.Signal.Explicit (Signal', SClock, register, systemClock)
 import CLaSH.Signal.Bundle   (Bundle (..), Unbundled')
 
 {- $setup
@@ -41,85 +39,8 @@ let mac s (x,y) = x * y + s
 >>> let topEntity = moore' clkA mac id 0
 -}
 
-{-# INLINE moore #-}
--- | Create a synchronous function from a combinational function describing
--- a moore machine
---
--- @
--- mac :: Int        -- Current state
---     -> (Int,Int)  -- Input
---     -> Int        -- Updated state
--- mac s (x,y) = x * y + s
---
--- topEntity :: 'Signal' (Int, Int) -> 'Signal' Int
--- topEntity = 'moore' mac id 0
--- @
---
--- >>> simulate topEntity [(1,1),(2,2),(3,3),(4,4)]
--- [0,1,5,14...
---
--- Synchronous sequential functions can be composed just like their
--- combinational counterpart:
---
--- @
--- dualMac :: ('Signal' Int, 'Signal' Int)
---         -> ('Signal' Int, 'Signal' Int)
---         -> 'Signal' Int
--- dualMac (a,b) (x,y) = s1 + s2
---   where
---     s1 = 'moore' mac id 0 ('CLaSH.Signal.bundle' (a,x))
---     s2 = 'moore' mac id 0 ('CLaSH.Signal.bundle' (b,y))
--- @
-moore :: (s -> i -> s) -- ^ Transfer function in moore machine form:
-                       -- @state -> input -> newstate@
-      -> (s -> o)      -- ^ Output function in moore machine form:
-                       -- @state -> output@
-      -> s             -- ^ Initial state
-      -> (Signal i -> Signal o)
-      -- ^ Synchronous sequential function with input and output matching that
-      -- of the moore machine
-moore = moore' systemClock
 
-{-# INLINE mooreB #-}
--- | A version of 'moore' that does automatic 'Bundle'ing
---
--- Given a functions @t@ and @o@ of types:
---
--- @
--- __t__ :: Int -> (Bool, Int) -> Int
--- __o__ :: Int -> (Int, Bool)
--- @
---
--- When we want to make compositions of @t@ and @o@ in @g@ using 'moore', we have to
--- write:
---
--- @
--- g a b c = (b1,b2,i2)
---   where
---     (i1,b1) = 'CLaSH.Signal.unbundle' ('moore' t o 0 ('CLaSH.Signal.bundle' (a,b)))
---     (i2,b2) = 'CLaSH.Signal.unbundle' ('moore' t o 3 ('CLaSH.Signal.bundle' (i1,c)))
--- @
---
--- Using 'mooreB' however we can write:
---
--- @
--- g a b c = (b1,b2,i2)
---   where
---     (i1,b1) = 'mooreB' t o 0 (a,b)
---     (i2,b2) = 'mooreB' t o 3 (i1,c)
--- @
-mooreB :: (Bundle i, Bundle o)
-      => (s -> i -> s) -- ^ Transfer function in moore machine form:
-                       -- @state -> input -> newstate@
-      -> (s -> o)      -- ^ Output function in moore machine form:
-                       -- @state -> output@
-      -> s             -- ^ Initial state
-      -> (Unbundled i -> Unbundled o)
-       -- ^ Synchronous sequential function with input and output matching that
-       -- of the moore machine
-mooreB = mooreB' systemClock
-
-{-# INLINABLE moore' #-}
+{-# INLINABLE moore #-}
 -- | Create a synchronous function from a combinational function describing
 -- a moore machine
 --
@@ -141,6 +62,14 @@ mooreB = mooreB' systemClock
 -- >>> simulate topEntity [(1,1),(2,2),(3,3),(4,4)]
 -- [0,1,5,14...
 --
+-- @
+-- topEntity :: 'Signal' (Int, Int) -> 'Signal' Int
+-- topEntity = 'moore' mac id 0
+-- @
+--
+-- >>> simulate topEntity [(1,1),(2,2),(3,3),(4,4)]
+-- [0,1,5,14...
+--
 -- Synchronous sequential functions can be composed just like their
 -- combinational counterpart:
 --
@@ -153,20 +82,20 @@ mooreB = mooreB' systemClock
 --     s1 = 'moore'' clkA mac id 0 ('CLaSH.Signal.Explicit.bundle'' clkA (a,x))
 --     s2 = 'moore'' clkA mac id 0 ('CLaSH.Signal.Explicit.bundle'' clkA (b,y))
 -- @
-moore' :: SClock clk    -- ^ 'Clock' to synchronize to
-       -> (s -> i -> s) -- ^ Transfer function in moore machine form:
-                        -- @state -> input -> newstate@
-       -> (s -> o)      -- ^ Output function in moore machine form:
-                        -- @state -> output@
-       -> s             -- ^ Initial state
-       -> (Signal' clk i -> Signal' clk o)
-       -- ^ Synchronous sequential function with input and output matching that
-       -- of the moore machine
-moore' clk ft fo iS = \i -> let s' = ft <$> s <*> i
-                                s  = register' clk iS s'
-                        in fo <$> s
+moore :: (?clk :: SClock clk) -- ^ 'Clock' to synchronize to
+      => (s -> i -> s)        -- ^ Transfer function in moore machine form:
+                              -- @state -> input -> newstate@
+      -> (s -> o)             -- ^ Output function in moore machine form:
+                              -- @state -> output@
+      -> s                    -- ^ Initial state
+      -> (Signal' clk i -> Signal' clk o)
+      -- ^ Synchronous sequential function with input and output matching that
+      -- of the moore machine
+moore ft fo iS = \i -> let s' = ft <$> s <*> i
+                           s  = register iS s'
+                   in fo <$> s
 
-{-# INLINE mooreB' #-}
+{-# INLINE mooreB #-}
 -- | A version of 'moore'' that does automatic 'Bundle'ing
 --
 -- Given a functions @t@ and @o@ of types:
@@ -194,14 +123,14 @@ moore' clk ft fo iS = \i -> let s' = ft <$> s <*> i
 --     (i1,b1) = 'mooreB'' clk t o 0 (a,b)
 --     (i2,b2) = 'mooreB'' clk to 3 (i1,c)
 -- @
-mooreB' :: (Bundle i, Bundle o)
-        => SClock clk
-        -> (s -> i -> s) -- ^ Transfer function in moore machine form:
-                         -- @state -> input -> newstate@
-        -> (s -> o)      -- ^ Output function in moore machine form:
-                         -- @state -> output@
-        -> s             -- ^ Initial state
-        -> (Unbundled' clk i -> Unbundled' clk o)
-        -- ^ Synchronous sequential function with input and output matching that
-        -- of the moore machine
-mooreB' clk ft fo iS i = unbundle' clk (moore' clk ft fo iS (bundle' clk i))
+mooreB :: (Bundle i, Bundle o)
+       => (?clk :: SClock clk) -- ^ 'Clock' to synchronize to
+       => (s -> i -> s)        -- ^ Transfer function in moore machine form:
+                               -- @state -> input -> newstate@
+       -> (s -> o)             -- ^ Output function in moore machine form:
+                               -- @state -> output@
+       -> s                    -- ^ Initial state
+       -> (Unbundled' clk i -> Unbundled' clk o)
+       -- ^ Synchronous sequential function with input and output matching that
+       -- of the moore machine
+mooreB ft fo iS i = unbundle' ?clk (moore ft fo iS (bundle' ?clk i))

--- a/src/CLaSH/Prelude/Safe.hs
+++ b/src/CLaSH/Prelude/Safe.hs
@@ -117,7 +117,7 @@ import CLaSH.Class.Resize
 import CLaSH.Prelude.BitIndex
 import CLaSH.Prelude.BitReduction
 import CLaSH.Prelude.BlockRam      (blockRam, blockRamPow2)
-import CLaSH.Prelude.Explicit.Safe (registerB', isRising', isFalling')
+import CLaSH.Prelude.Explicit.Safe (registerB, isRising, isFalling)
 import CLaSH.Prelude.Mealy         (mealy, mealyB, (<^>))
 import CLaSH.Prelude.Moore         (moore, mooreB)
 import CLaSH.Prelude.RAM           (asyncRam,asyncRamPow2)
@@ -150,30 +150,3 @@ splitAt, tail, take, unzip, unzip3, zip, zip3, zipWith, zipWith3.
 It instead exports the identically named functions defined in terms of
 'CLaSH.Sized.Vector.Vec' at "CLaSH.Sized.Vector".
 -}
-
-{-# INLINE registerB #-}
--- | Create a 'register' function for product-type like signals (e.g. '(Signal a, Signal b)')
---
--- > rP :: (Signal Int,Signal Int) -> (Signal Int, Signal Int)
--- > rP = registerB (8,8)
---
--- >>> simulateB rP [(1,1),(2,2),(3,3)] :: [(Int,Int)]
--- [(8,8),(1,1),(2,2),(3,3)...
-registerB :: Bundle a => a -> Unbundled a -> Unbundled a
-registerB = registerB' systemClock
-
-{-# INLINE isRising #-}
--- | Give a pulse when the 'Signal' goes from 'minBound' to 'maxBound'
-isRising :: (Bounded a, Eq a)
-         => a -- ^ Starting value
-         -> Signal a
-         -> Signal Bool
-isRising = isRising' systemClock
-
-{-# INLINE isFalling #-}
--- | Give a pulse when the 'Signal' goes from 'maxBound' to 'minBound'
-isFalling :: (Bounded a, Eq a)
-          => a -- ^ Starting value
-          -> Signal a
-          -> Signal Bool
-isFalling = isFalling' systemClock

--- a/src/CLaSH/Signal.hs
+++ b/src/CLaSH/Signal.hs
@@ -70,7 +70,7 @@ import CLaSH.Signal.Internal (Signal', register#, regEn#, (.==.), (./=.),
                               unsafeShiftL1, shiftR1, unsafeShiftR1, rotateL1,
                               rotateR1, (.||.), (.&&.), not1, mux, sample,
                               sampleN, fromList, simulate, signal, testFor)
-import CLaSH.Signal.Explicit (SystemClock, systemClock, simulateB')
+import CLaSH.Signal.Explicit (SystemClock, systemClock, register, regEn, simulateB)
 import CLaSH.Signal.Bundle   (Bundle (..), Unbundled')
 
 {- $setup
@@ -82,35 +82,6 @@ import CLaSH.Signal.Bundle   (Bundle (..), Unbundled')
 
 -- | Signal synchronised to the \"system\" clock, which has a period of 1000.
 type Signal a = Signal' SystemClock a
-
--- * Basic circuit functions
-
-{-# INLINE register #-}
--- | 'register' @i s@ delays the values in 'Signal' @s@ for one cycle, and sets
--- the value at time 0 to @i@
---
--- >>> sampleN 3 (register 8 (fromList [1,2,3,4]))
--- [8,1,2]
-register :: a -> Signal a -> Signal a
-register = register# systemClock
-
-{-# INLINE regEn #-}
--- | Version of 'register' that only updates its content when its second argument
--- is asserted. So given:
---
--- @
--- oscillate = 'register' False ('not1' oscillate)
--- count     = 'regEn' 0 oscillate (count + 1)
--- @
---
--- We get:
---
--- >>> sampleN 8 oscillate
--- [False,True,False,True,False,True,False,True]
--- >>> sampleN 8 count
--- [0,0,1,1,2,2,3,3]
-regEn :: a -> Signal Bool -> Signal a -> Signal a
-regEn = regEn# systemClock
 
 -- * Product/Signal isomorphism
 
@@ -147,13 +118,3 @@ unbundle = unbundle' systemClock
 -- @
 bundle :: Bundle a => Unbundled a -> Signal a
 bundle = bundle' systemClock
-
--- | Simulate a (@'Unbundled' a -> 'Unbundled' b@) function given a list of
--- samples of type @a@
---
--- >>> simulateB (unbundle . register (8,8) . bundle) [(1,1), (2,2), (3,3)] :: [(Int,Int)]
--- [(8,8),(1,1),(2,2),(3,3)...
---
--- __NB__: This function is not synthesisable
-simulateB :: (Bundle a, Bundle b) => (Unbundled a -> Unbundled b) -> [a] -> [b]
-simulateB = simulateB' systemClock systemClock

--- a/src/CLaSH/Signal/Delayed.hs
+++ b/src/CLaSH/Signal/Delayed.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ImplicitParams             #-}
 {-# LANGUAGE DataKinds                  #-}
 {-# LANGUAGE DeriveTraversable          #-}
 {-# LANGUAGE GADTs                      #-}
@@ -51,6 +52,7 @@ import CLaSH.Promoted.Nat         (SNat)
 import CLaSH.Sized.Vector         (Vec, head, length, repeat, shiftInAt0,
                                    singleton)
 import CLaSH.Signal               (Signal, fromList, register, bundle, unbundle)
+import CLaSH.Signal.Explicit      (SClock, SystemClock)
 
 {- $setup
 >>> :set -XDataKinds
@@ -113,6 +115,7 @@ dfromList = coerce . fromList
 -- >>> sampleN 6 (delay3 (dfromList [1..]))
 -- [0,0,0,1,2,3]
 delay :: forall a n d . KnownNat d
+      => (?clk :: SClock SystemClock)
       => Vec d a
       -> DSignal n a
       -> DSignal (n + d) a
@@ -135,6 +138,7 @@ delay m ds = coerce (delay' (coerce ds))
 -- >>> sampleN 6 (delay2 (dfromList [1..]))
 -- [0,0,1,2,3,4]
 delayI :: (Default a, KnownNat d)
+       => (?clk :: SClock SystemClock)
        => DSignal n a
        -> DSignal (n + d) a
 delayI = delay (repeat def)


### PR DESCRIPTION
It once occurred to me that the propagation of `SClock`s matches the routing of clock lines [I brought this up on IRC a while back]. The match is exact if it is changed so `SClock`s cannot be synthesized so `topLevel` must have parameters for all `SClock` clock lines. I then thought that we could leverage that to avoid having to add the clock lines manually during the compilation process.

Of course, routing clock lines is boring chore, but implicit parameters can largely automate the process. This patch uses them to do just that, without messing with the templated functions so that it should work with today's clash-compiler.

I see two downsides:
-  Unlike Agda and Lean's implicit parameters, Haskell's use the name of the binding, rather than the type, to infer the arguments, and also provides no way to positional manually instantiate the parameter. This leads one to do things awkward things like `let ?clk1 = wclk; ?clk2 = rclk in unsafeSynchronize` rather than `unsafeSynchronize ?wclk ?rclk` or just `unsafeSynchronize`. [See `CLaSH/Prelude/Synchronizer.hs` for good examples of this.]
- GHC might inline the `SClocks` it thinks are irelevant before clash gets a chance to leverage them.

I also see that with `ghc8` branch it looks like you are trying to remove the need for `SClock`s in most code altogether. That might be a better route in the short term as it avoids the awkwardness that is my first downside. But that looses out on the ability to leverage them for simplifying compilation. I also wonder how hard it would be to change the way implicit parameters worked or make a new extension.

This is `WIP` because I have only tested that it type checks (with GHC 7.10), and haven't bothered to fix the docs / doc tests.
