### PR TITLE
Export `readNew` from the preludes too

### DIFF
--- a/src/CLaSH/Prelude.hs
+++ b/src/CLaSH/Prelude.hs
@@ -60,6 +60,9 @@ module CLaSH.Prelude
     -- ** BlockRAM primitives initialised with a data file
   , blockRamFile
   , blockRamFilePow2
+    -- * BlockRAM read/write conflict resolution
+  , readNew
+  , readNew'
     -- * Utility functions
   , window
   , windowD

--- a/src/CLaSH/Prelude/Safe.hs
+++ b/src/CLaSH/Prelude/Safe.hs
@@ -53,6 +53,9 @@ module CLaSH.Prelude.Safe
     -- * BlockRAM primitives
   , blockRam
   , blockRamPow2
+    -- * BlockRAM read/write conflict resolution
+  , readNew
+  , readNew'
     -- * Utility functions
   , isRising
   , isFalling
@@ -116,7 +119,7 @@ import CLaSH.Class.Num
 import CLaSH.Class.Resize
 import CLaSH.Prelude.BitIndex
 import CLaSH.Prelude.BitReduction
-import CLaSH.Prelude.BlockRam      (blockRam, blockRamPow2)
+import CLaSH.Prelude.BlockRam      (blockRam, blockRamPow2, readNew, readNew')
 import CLaSH.Prelude.Explicit.Safe (registerB', isRising', isFalling')
 import CLaSH.Prelude.Mealy         (mealy, mealyB, (<^>))
 import CLaSH.Prelude.Moore         (moore, mooreB)


### PR DESCRIPTION
Unfortunately I just noticed that the adapter functions weren't exported.