### PR TITLE
bump ghc-typelits-knownnat

### DIFF
--- a/clash-prelude.cabal
+++ b/clash-prelude.cabal
@@ -174,7 +174,7 @@ Library
                       deepseq                   >= 1.4.1.0 && < 1.5,
                       ghc-prim                  >= 0.3.1.0 && < 0.6,
                       ghc-typelits-extra        >= 0.2.1   && < 0.3,
-                      ghc-typelits-knownnat     >= 0.1.2   && < 0.3,
+                      ghc-typelits-knownnat     >= 0.2.2   && < 0.3,
                       ghc-typelits-natnormalise >= 0.4.2   && < 0.6,
                       lens                      >= 4.9     && < 4.15,
                       QuickCheck                >= 2.7     && < 2.10,


### PR DESCRIPTION
Otherwise there is an error in
```
[ 7 of 48] Compiling CLaSH.Promoted.Nat ( src/CLaSH/Promoted/Nat.hs, dist/build/CLaSH/Promoted/Nat.o )

src/CLaSH/Promoted/Nat.hs:186:21: error:
    ? Could not deduce (KnownNat a) arising from a use of ?SNat?
      from the context: KnownNat (a + b)
```