### PR TITLE
stack.yaml: update to lts-8.3

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2016-07-19
+resolver: lts-8.3
 
 packages:
 - .


### PR DESCRIPTION
LTS 8.x uses ghc-8.0.2, which is now needed for the clash compiler. This also allows `clash build` to work out of the box (e.g. with a system-installed GHC)