### PR TITLE
Add leToPlus function

### DIFF
--- a/src/CLaSH/Promoted/Nat.hs
+++ b/src/CLaSH/Promoted/Nat.hs
@@ -437,8 +437,9 @@ leToPlus
   -> (forall m . f (m + k) -> r)
   -> r
 leToPlus a f = f @ (n-k) a
+{-# INLINE leToPlus #-}
 
--- | Same as 'leToPlus' with an added 'KnownNat' constraint
+-- | Same as 'leToPlus' with added 'KnownNat' constraints
 leToPlusKN
   :: forall (k :: Nat) (n :: Nat) f r
    . (k <= n, KnownNat n, KnownNat k)
@@ -446,3 +447,4 @@ leToPlusKN
   -> (forall m . KnownNat m => f (m + k) -> r)
   -> r
 leToPlusKN a f = f @ (n-k) a
+{-# INLINE leToPlusKN #-}

--- a/src/CLaSH/Promoted/Nat.hs
+++ b/src/CLaSH/Promoted/Nat.hs
@@ -4,12 +4,16 @@ License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-{-# LANGUAGE DataKinds      #-}
-{-# LANGUAGE GADTs          #-}
-{-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE MagicHash      #-}
-{-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE TypeOperators  #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE KindSignatures      #-}
+{-# LANGUAGE MagicHash           #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell     #-}
+{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeOperators       #-}
+{-# LANGUAGE RankNTypes          #-}
 
 {-# LANGUAGE Trustworthy #-}
 
@@ -58,6 +62,9 @@ module CLaSH.Promoted.Nat
   , predBNat, div2BNat, div2Sub1BNat, log2BNat
     -- ** Normalisation
   , stripZeros
+    -- * Constraints
+  , leToPlus
+  , leToPlusKN
   )
 where
 
@@ -420,3 +427,22 @@ stripZeros (B0 BT) = BT
 stripZeros (B0 x)  = case stripZeros x of
   BT -> BT
   k  -> B0 k
+
+-- | Change constraints from the form (n + k) to the form (k <= n)
+-- This can be useful to simplify constraints
+leToPlus
+  :: forall (k :: Nat) (n :: Nat) f r
+   . (k <= n)
+  => f n
+  -> (forall m . f (m + k) -> r)
+  -> r
+leToPlus a f = f @ (n-k) a
+
+-- | Same as 'leToPlus' with an added 'KnownNat' constraint
+leToPlusKN
+  :: forall (k :: Nat) (n :: Nat) f r
+   . (k <= n, KnownNat n, KnownNat k)
+  => f n
+  -> (forall m . KnownNat m => f (m + k) -> r)
+  -> r
+leToPlusKN a f = f @ (n-k) a

--- a/src/CLaSH/Sized/Internal/Index.hs
+++ b/src/CLaSH/Sized/Internal/Index.hs
@@ -19,7 +19,6 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 {-# LANGUAGE Unsafe #-}
 
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.KnownNat.Solver #-}
-{-# OPTIONS_GHC -fconstraint-solver-iterations=0      #-}
 {-# OPTIONS_HADDOCK show-extensions #-}
 
 module CLaSH.Sized.Internal.Index

--- a/src/CLaSH/Sized/Internal/Index.hs
+++ b/src/CLaSH/Sized/Internal/Index.hs
@@ -19,6 +19,7 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 {-# LANGUAGE Unsafe #-}
 
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.KnownNat.Solver #-}
+{-# OPTIONS_GHC -fconstraint-solver-iterations=0      #-}
 {-# OPTIONS_HADDOCK show-extensions #-}
 
 module CLaSH.Sized.Internal.Index
@@ -66,6 +67,7 @@ where
 import Control.DeepSeq            (NFData (..))
 import Data.Data                  (Data)
 import Data.Default               (Default (..))
+import Data.Function              (on)
 import Data.Proxy                 (Proxy (..))
 import Text.Read                  (Read (..), ReadPrec)
 import Language.Haskell.TH        (TypeQ, appT, conT, litT, numTyLit, sigE)
@@ -82,7 +84,7 @@ import CLaSH.Class.Num            (ExtendingNum (..), SaturatingNum (..),
                                    SaturationMode (..))
 import CLaSH.Class.Resize         (Resize (..))
 import {-# SOURCE #-} CLaSH.Sized.Internal.BitVector (BitVector (BV))
-import CLaSH.Promoted.Nat         (SNat, snatToNum)
+import CLaSH.Promoted.Nat         (SNat, snatToNum, leToPlusKN)
 import CLaSH.XException           (ShowX (..), showsPrecXWith)
 
 -- | Arbitrary-bounded unsigned integer represented by @ceil(log_2(n))@ bits.
@@ -252,19 +254,28 @@ minus# (I a) (I b) =
 times# :: Index m -> Index n -> Index (((m - 1) * (n - 1)) + 1)
 times# (I a) (I b) = I (a * b)
 
-instance (KnownNat n, 1 <= (n*2), (n*2) <= (n^2)) => SaturatingNum (Index n) where
-  satPlus SatWrap a b = case plus# a b of
-    z | let m = fromInteger# (natVal (Proxy @ n))
-      , z >= m -> resize# (z - m)
-    z -> resize# z
-  satPlus SatZero a b = case plus# a b of
-    z | let m = fromInteger# (natVal (Proxy @ n))
-      , z >= m -> fromInteger# 0
-    z -> resize# z
-  satPlus _ a b = case plus# a b of
-    z | let m = fromInteger# (natVal (Proxy @ n))
-      , z >= m -> maxBound#
-    z -> resize# z
+instance (KnownNat n, 1 <= n) => SaturatingNum (Index n) where
+  satPlus SatWrap a b =
+    leToPlusKN @1 @n a $ \a' ->
+    leToPlusKN @1 @n b $ \b' ->
+      case plus# a' b' of
+        z | let m = fromInteger# (natVal (Proxy @ n))
+          , z >= m -> resize# (z - m)
+        z -> resize# z
+  satPlus SatZero a b =
+    leToPlusKN @1 @n a $ \a' ->
+    leToPlusKN @1 @n b $ \b' ->
+      case plus# a' b' of
+        z | let m = fromInteger# (natVal (Proxy @ n))
+          , z >= m -> fromInteger# 0
+        z -> resize# z
+  satPlus _ a b =
+    leToPlusKN @1 @n a $ \a' ->
+    leToPlusKN @1 @n b $ \b' ->
+      case plus# a' b' of
+        z | let m = fromInteger# (natVal (Proxy @ n))
+          , z >= m -> maxBound#
+        z -> resize# z
 
   satMin SatWrap a b =
     if lt# a b
@@ -276,18 +287,27 @@ instance (KnownNat n, 1 <= (n*2), (n*2) <= (n^2)) => SaturatingNum (Index n) whe
        then fromInteger# 0
        else a -# b
 
-  satMult SatWrap a b = case times# a b of
-    z | let m = fromInteger# (natVal (Proxy @ n))
-      , z >= m -> resize# (z - m)
-    z -> resize# z
-  satMult SatZero a b = case times# a b of
-    z | let m = fromInteger# (natVal (Proxy @ n))
-      , z >= m -> fromInteger# 0
-    z -> resize# z
-  satMult _ a b = case times# a b of
-    z | let m = fromInteger# (natVal (Proxy @ n))
-      , z >= m -> maxBound#
-    z -> resize# z
+  satMult SatWrap a b =
+    leToPlusKN @1 @n a $ \a' ->
+    leToPlusKN @1 @n b $ \b' ->
+      case times# a' b' of
+        z | let m = fromInteger# (natVal (Proxy @ n))
+          , z >= m -> resize# (z - m)
+        z -> resize# z
+  satMult SatZero a b =
+    leToPlusKN @1 @n a $ \a' ->
+    leToPlusKN @1 @n b $ \b' ->
+      case times# a' b' of
+        z | let m = fromInteger# (natVal (Proxy @ n))
+          , z >= m -> fromInteger# 0
+        z -> resize# z
+  satMult _ a b =
+    leToPlusKN @1 @n a $ \a' ->
+    leToPlusKN @1 @n b $ \b' ->
+      case times# a' b' of
+        z | let m = fromInteger# (natVal (Proxy @ n))
+          , z >= m -> maxBound#
+        z -> resize# z
 
 instance KnownNat n => Real (Index n) where
   toRational = toRational . toInteger#

--- a/src/CLaSH/Sized/Internal/Index.hs
+++ b/src/CLaSH/Sized/Internal/Index.hs
@@ -255,22 +255,22 @@ times# (I a) (I b) = I (a * b)
 
 instance (KnownNat n, 1 <= n) => SaturatingNum (Index n) where
   satPlus SatWrap a b =
-    leToPlusKN @1 @n a $ \a' ->
-    leToPlusKN @1 @n b $ \b' ->
+    leToPlusKN @1 a $ \a' ->
+    leToPlusKN @1 b $ \b' ->
       case plus# a' b' of
         z | let m = fromInteger# (natVal (Proxy @ n))
           , z >= m -> resize# (z - m)
         z -> resize# z
   satPlus SatZero a b =
-    leToPlusKN @1 @n a $ \a' ->
-    leToPlusKN @1 @n b $ \b' ->
+    leToPlusKN @1 a $ \a' ->
+    leToPlusKN @1 b $ \b' ->
       case plus# a' b' of
         z | let m = fromInteger# (natVal (Proxy @ n))
           , z >= m -> fromInteger# 0
         z -> resize# z
   satPlus _ a b =
-    leToPlusKN @1 @n a $ \a' ->
-    leToPlusKN @1 @n b $ \b' ->
+    leToPlusKN @1 a $ \a' ->
+    leToPlusKN @1 b $ \b' ->
       case plus# a' b' of
         z | let m = fromInteger# (natVal (Proxy @ n))
           , z >= m -> maxBound#
@@ -287,22 +287,22 @@ instance (KnownNat n, 1 <= n) => SaturatingNum (Index n) where
        else a -# b
 
   satMult SatWrap a b =
-    leToPlusKN @1 @n a $ \a' ->
-    leToPlusKN @1 @n b $ \b' ->
+    leToPlusKN @1 a $ \a' ->
+    leToPlusKN @1 b $ \b' ->
       case times# a' b' of
         z | let m = fromInteger# (natVal (Proxy @ n))
           , z >= m -> resize# (z - m)
         z -> resize# z
   satMult SatZero a b =
-    leToPlusKN @1 @n a $ \a' ->
-    leToPlusKN @1 @n b $ \b' ->
+    leToPlusKN @1 a $ \a' ->
+    leToPlusKN @1 b $ \b' ->
       case times# a' b' of
         z | let m = fromInteger# (natVal (Proxy @ n))
           , z >= m -> fromInteger# 0
         z -> resize# z
   satMult _ a b =
-    leToPlusKN @1 @n a $ \a' ->
-    leToPlusKN @1 @n b $ \b' ->
+    leToPlusKN @1 a $ \a' ->
+    leToPlusKN @1 b $ \b' ->
       case times# a' b' of
         z | let m = fromInteger# (natVal (Proxy @ n))
           , z >= m -> maxBound#


### PR DESCRIPTION
The `leToPlus` function enables the creation of simpler constraints. The
`SaturatingNum` instance for `Index` has been changed to a weaker
constraint: from `(KnownNat n, 1 <= (n*2), (n*2) <= (n^2))` to `(KnownNat
n, 1 <= n)`.