### PR TITLE
Fix mentions of CLaSH.Explicit.Prelude

### DIFF
--- a/src/CLaSH/Explicit/Prelude/Safe.hs
+++ b/src/CLaSH/Explicit/Prelude/Safe.hs
@@ -4,7 +4,7 @@ Copyright  :  (C) 2013-2016, University of Twente,
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 
-__This is the <https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/safe-haskell.html Safe> API only of "CLaSH.Prelude.Explicit"__
+__This is the <https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/safe-haskell.html Safe> API only of "CLaSH.Explicit.Prelude"__
 
 This module defines the explicitly clocked counterparts of the functions
 defined in "CLaSH.Prelude". Take a look at "CLaSH.Signal.Explicit" to see how

--- a/src/CLaSH/Prelude/Safe.hs
+++ b/src/CLaSH/Prelude/Safe.hs
@@ -20,7 +20,7 @@
   To use the library:
 
   * Import "CLaSH.Prelude"
-  * Additionally import "CLaSH.Prelude.Explicit" if you want to design
+  * Additionally import "CLaSH.Explicit.Prelude" if you want to design
     explicitly clocked circuits in a multi-clock setting
 
   For now, "CLaSH.Prelude" is also the best starting point for exploring the

--- a/src/CLaSH/Tutorial.hs
+++ b/src/CLaSH/Tutorial.hs
@@ -1480,7 +1480,7 @@ it assumes that you are familiar with the design of synchronizer circuits, and
 why a dual flip-flop synchroniser only works for bit-synchronisation and not
 word-synchronisation.
 The explicitly clocked versions of all synchronous functions and primitives can
-be found in "CLaSH.Prelude.Explicit", which also re-exports the functions in
+be found in "CLaSH.Explicit.Prelude", which also re-exports the functions in
 "CLaSH.Signal.Explicit". We will use those functions to create a FIFO where
 the read and write port are synchronised to different clocks. Below you can find
 the code to build the FIFO synchroniser based on the design described in:
@@ -1494,7 +1494,7 @@ and resets must be explicitly routed:
 @
 module MultiClockFifo where
 
-import CLaSH.Prelude.Explicit
+import CLaSH.Explicit.Prelude
 import Data.Maybe             (isJust)
 import Data.Constraint.Nat    (leTrans)
 @
@@ -1650,7 +1650,7 @@ Ultimately, the whole file containing our FIFO design will look like this:
 module MultiClockFifo where
 
 import CLaSH.Prelude
-import CLaSH.Prelude.Explicit
+import CLaSH.Explicit.Prelude
 import Data.Maybe             (isJust)
 
 fifoMem wclk rclk addrSize wfull raddr wdataM =


### PR DESCRIPTION
Some missed cases. This also irritates doctest, I think.