### PR TITLE
Apply U.S. English consistently when referring to 'resetSynchroni*er'

### DIFF
--- a/src/Clash/Annotations/TopEntity.hs
+++ b/src/Clash/Annotations/TopEntity.hs
@@ -66,7 +66,7 @@ topEntity
   -> Signal Dom50 (BitVector 8)
 topEntity clk rst key1 =
     let  (pllOut,pllStable) = 'Clash.Intel.ClockGen.altpll' (SSymbol @ "altpll50") clk rst
-         rstSync            = 'Clash.Signal.resetSynchroniser' pllOut ('Clash.Signal.unsafeToAsyncReset' pllStable)
+         rstSync            = 'Clash.Signal.resetSynchronizer' pllOut ('Clash.Signal.unsafeToAsyncReset' pllStable)
     in   'Clash.Signal.withClockReset' pllOut rstSync leds
   where
     key1R  = 'Clash.Prelude.isRising' 1 key1

--- a/src/Clash/Explicit/Signal.hs
+++ b/src/Clash/Explicit/Signal.hs
@@ -287,7 +287,7 @@ systemReset = asyncResetGen
 -- | Normally, asynchronous resets can be both asynchronously asserted and
 -- de-asserted. Asynchronous de-assertion can induce meta-stability in the
 -- component which is being reset. To ensure this doesn't happen,
--- 'resetSynchroniser' ensures that de-assertion of a reset happens
+-- 'resetSynchronizer' ensures that de-assertion of a reset happens
 -- synchronously. Assertion of the reset remains asynchronous.
 --
 -- Note that asynchronous assertion does not induce meta-stability in the

--- a/src/Clash/Tutorial.hs
+++ b/src/Clash/Tutorial.hs
@@ -897,7 +897,7 @@ topEntity
   -> Signal Dom50 (BitVector 8)
 topEntity clk rst key1 =
     let  (pllOut,pllStable) = 'Clash.Intel.ClockGen.altpll' (SSymbol @ "altpll50") clk rst
-         rstSync            = 'Clash.Signal.resetSynchroniser' pllOut ('Clash.Signal.unsafeToAsyncReset' pllStable)
+         rstSync            = 'Clash.Signal.resetSynchronizer' pllOut ('Clash.Signal.unsafeToAsyncReset' pllStable)
     in   'Clash.Signal.withClockReset' pllOut rstSync leds
   where
     key1R  = 'Clash.Prelude.isRising' 1 key1


### PR DESCRIPTION
The tutorial and documentation incorrectly refer to a function called "resetSynchroniser", even though the implementation uses "resetSynchronizer". This PR fixes these references.