### PR TITLE
Fix for missing modules in doctests

### DIFF
--- a/tests/doctests.hs
+++ b/tests/doctests.hs
@@ -5,8 +5,8 @@ import Test.DocTest (doctest)
 
 main :: IO ()
 main = doctest (docTestOpts ++ ["-isrc","src/Clash/Prelude.hs"]) >>
-       doctest (docTestOpts ++ ["src/Clash/Tutorial.hs"]) >>
-       doctest (docTestOpts ++ ["src/Clash/Examples.hs"])
+       doctest (docTestOpts ++ ["-isrc","src/Clash/Tutorial.hs"]) >>
+       doctest (docTestOpts ++ ["-isrc","src/Clash/Examples.hs"])
 
 docTestOpts :: [String]
 docTestOpts =


### PR DESCRIPTION
This only affects the test when they are run with `cabal` (as opposed to being run with `stack`).

This is the error I was getting:

```
➜ cabal test
Resolving dependencies...
Configuring clash-prelude-0.99...
Preprocessing test suite 'doctests' for clash-prelude-0.99..
Building test suite 'doctests' for clash-prelude-0.99..
Running 1 test suites...
Test suite doctests: RUNNING...
Examples: 585  Tried: 585  Errors: 0  Failures: 0

src/Clash/Tutorial.hs:73:1: error:
    Could not find module ‘Clash.Prelude’
    Use -v to see a list of the files searched for.
   |
73 | import Clash.Prelude
   | ^^^^^^^^^^^^^^^^^^^^

src/Clash/Tutorial.hs:74:1: error:
    Could not find module ‘Clash.Explicit.Prelude’
    Use -v to see a list of the files searched for.
   |
74 | import Clash.Explicit.Prelude (freqCalc)
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Test suite doctests: FAIL
Test suite logged to: dist/test/clash-prelude-0.99-doctests.log
0 of 1 test suites (0 of 1 test cases) passed.
```