### PR TITLE
Implemented InOut ports

### DIFF
--- a/src/Clash/Explicit/Signal.hs
+++ b/src/Clash/Explicit/Signal.hs
@@ -138,7 +138,10 @@ meta-stability:
 
 module Clash.Explicit.Signal
   ( -- * Synchronous signal
-    Signal, Domain (..), System
+    Signal
+  , Domain (..)
+  , System
+  , InOut
     -- * Clock
   , Clock, ClockKind (..)
   , freqCalc

--- a/src/Clash/Signal.hs
+++ b/src/Clash/Signal.hs
@@ -51,6 +51,7 @@ module Clash.Signal
     Signal
   , Domain (..)
   , System
+  , InOut
     -- * Clock
   , Clock
   , ClockKind (..)

--- a/src/Clash/Signal/Internal.hs
+++ b/src/Clash/Signal/Internal.hs
@@ -30,6 +30,7 @@ module Clash.Signal.Internal
   ( -- * Datatypes
     Domain (..)
   , Signal (..)
+  , InOut
     -- * Clocks
   , Clock (..)
   , ClockKind (..)
@@ -253,6 +254,9 @@ instance Traversable (Signal domain) where
 {-# NOINLINE traverse# #-}
 traverse# :: Applicative f => (a -> f b) -> Signal domain a -> f (Signal domain b)
 traverse# f (a :- s) = (:-) <$> f a <*> traverse# f s
+
+-- Passthrough `token` for inout ports
+data InOut (domain :: Domain) a
 
 -- * Clocks and resets
 

--- a/src/Clash/Signal/Internal.hs
+++ b/src/Clash/Signal/Internal.hs
@@ -255,7 +255,22 @@ instance Traversable (Signal domain) where
 traverse# :: Applicative f => (a -> f b) -> Signal domain a -> f (Signal domain b)
 traverse# f (a :- s) = (:-) <$> f a <*> traverse# f s
 
--- Passthrough `token` for inout ports
+-- | Similar to @Signal@, but indicates this port should be bidirectional in the target HDL.
+--
+-- === Usage example
+--
+-- > example
+-- >   :: Clock System Source
+-- >   -> Reset System Asynchronous
+-- >   -> InOut System (BitVector 16)
+-- >   -> Signal System Bool
+-- > example clk rst data = ...
+--
+-- Note that there is no way to simulate inout ports. It is merely a way to passthrough such
+-- a port. This might be used in combination with an existing IP component (for example, a
+-- DRAM controller).
+--
+-- __NB__ Can be as an input, as well as (a component of) an output
 data InOut (domain :: Domain) a
 
 -- * Clocks and resets


### PR DESCRIPTION
This patch adds support for `inout` ports according to [this](https://github.com/clash-lang/clash-compiler/wiki/Plan-for-%60inout%60-signals) plan and [this](https://github.com/clash-lang/clash-compiler/issues/231#issuecomment-335721415) comment. This has been tested by implementing a simple program for a DRAM controller (PR coming soon-ish).

Should be merged in tandem with: https://github.com/clash-lang/clash-compiler/pull/262