### PR TITLE
Use the `reflection` package for implicit clocks and resets

### DIFF
--- a/src/Clash/Annotations/TopEntity.hs
+++ b/src/Clash/Annotations/TopEntity.hs
@@ -67,7 +67,7 @@ topEntity
 topEntity clk rst key1 =
     let  (pllOut,pllStable) = 'Clash.Intel.ClockGen.altpll' (SSymbol @ "altpll50") clk rst
          rstSync            = 'Clash.Signal.resetSynchronizer' pllOut ('Clash.Signal.unsafeToAsyncReset' pllStable)
-    in   'Clash.Signal.withClockReset' pllOut rstSync leds
+    in   'Clash.Signal.exposeClockReset' leds pllOut rstSync
   where
     key1R  = 'Clash.Prelude.isRising' 1 key1
     leds   = 'Clash.Prelude.mealy' blinkerT (1,False,0) key1R

--- a/src/Clash/Explicit/BlockRam.hs
+++ b/src/Clash/Explicit/BlockRam.hs
@@ -120,13 +120,13 @@ We initially create a memory out of simple registers:
 
 @
 dataMem
-  :: Clock System gated
-  -> Reset System synchronous
-  -> Signal MemAddr
+  :: Clock domain gated
+  -> Reset domain synchronous
+  -> Signal domain MemAddr
   -- ^ Read address
-  -> Signal (Maybe (MemAddr,Value))
+  -> Signal domain (Maybe (MemAddr,Value))
   -- ^ (write address, data in)
-  -> Signal Value
+  -> Signal domain Value
   -- ^ data out
 dataMem clk rst rd wrM = 'Clash.Explicit.Mealy.mealy' clk rst dataMemT ('Clash.Sized.Vector.replicate' d32 0) (bundle (rd,wrM))
   where
@@ -144,9 +144,9 @@ And then connect everything:
 system
   :: KnownNat n
   => Vec n Instruction
-  -> Clock System gated
-  -> Reset System synchronous
-  -> Signal System Value
+  -> Clock domain gated
+  -> Reset domain synchronous
+  -> Signal domain Value
 system instrs clk rst = memOut
   where
     memOut = dataMem clk rst rdAddr dout
@@ -211,9 +211,9 @@ has the potential to be translated to a more efficient structure:
 system2
   :: KnownNat n
   => Vec n Instruction
-  -> Clock System gated
-  -> Reset System synchronous
-  -> Signal System Value
+  -> Clock domain gated
+  -> Reset domain synchronous
+  -> Signal domain Value
 system2 instrs clk rst = memOut
   where
     memOut = 'Clash.Explicit.RAM.asyncRam' clk clk d32 rdAddr dout
@@ -301,9 +301,9 @@ We can now finally instantiate our system with a 'blockRam':
 system3
   :: KnownNat n
   => Vec n Instruction
-  -> Clock System gated
-  -> Reset System synchronous
-  -> Signal System Value
+  -> Clock domain gated
+  -> Reset domain synchronous
+  -> Signal domain Value
 system3 instrs clk rst = memOut
   where
     memOut = 'blockRam' clk (replicate d32 0) rdAddr dout
@@ -505,11 +505,11 @@ cpu regbank (memOut,instr) = (regbank',(rdAddr,(,aluOut) <$> wrAddrM,fromIntegra
 
 >>> :{
 dataMem
-  :: Clock  System gated
-  -> Reset  System synchronous
-  -> Signal System MemAddr
-  -> Signal System (Maybe (MemAddr,Value))
-  -> Signal System Value
+  :: Clock  domain gated
+  -> Reset  domain synchronous
+  -> Signal domain MemAddr
+  -> Signal domain (Maybe (MemAddr,Value))
+  -> Signal domain Value
 dataMem clk rst rd wrM = mealy clk rst dataMemT (C.replicate d32 0) (bundle (rd,wrM))
   where
     dataMemT mem (rd,wrM) = (mem',dout)
@@ -524,9 +524,9 @@ dataMem clk rst rd wrM = mealy clk rst dataMemT (C.replicate d32 0) (bundle (rd,
 system
   :: KnownNat n
   => Vec n Instruction
-  -> Clock System gated
-  -> Reset System synchronous
-  -> Signal System Value
+  -> Clock domain gated
+  -> Reset domain synchronous
+  -> Signal domain Value
 system instrs clk rst = memOut
   where
     memOut = dataMem clk rst rdAddr dout
@@ -570,9 +570,9 @@ prog = -- 0 := 4
 system2
   :: KnownNat n
   => Vec n Instruction
-  -> Clock System gated
-  -> Reset System synchronous
-  -> Signal System Value
+  -> Clock domain gated
+  -> Reset domain synchronous
+  -> Signal domain Value
 system2 instrs clk rst = memOut
   where
     memOut = asyncRam clk clk d32 rdAddr dout
@@ -619,9 +619,9 @@ cpu2 (regbank,ldRegD) (memOut,instr) = ((regbank',ldRegD'),(rdAddr,(,aluOut) <$>
 system3
   :: KnownNat n
   => Vec n Instruction
-  -> Clock System gated
-  -> Reset System synchronous
-  -> Signal System Value
+  -> Clock domain gated
+  -> Reset domain synchronous
+  -> Signal domain Value
 system3 instrs clk rst = memOut
   where
     memOut = blockRam clk (C.replicate d32 0) rdAddr dout
@@ -669,10 +669,10 @@ prog2 = -- 0 := 4
 -- * __NB__: Initial output value is 'undefined'
 --
 -- @
--- bram40 :: 'Clock'  System gated
---        -> 'Signal' System ('Unsigned' 6)
---        -> 'Signal' System (Maybe ('Unsigned' 6, 'Clash.Sized.BitVector.Bit'))
---        -> 'Signal' System 'Clash.Sized.BitVector.Bit'
+-- bram40 :: 'Clock'  domain gated
+--        -> 'Signal' domain ('Unsigned' 6)
+--        -> 'Signal' domain (Maybe ('Unsigned' 6, 'Clash.Sized.BitVector.Bit'))
+--        -> 'Signal' domain 'Clash.Sized.BitVector.Bit'
 -- bram40 clk = 'blockRam' clk ('Clash.Sized.Vector.replicate' d40 1)
 -- @
 --
@@ -709,9 +709,9 @@ blockRam = \clk content rd wrM ->
 -- * __NB__: Initial output value is 'undefined'
 --
 -- @
--- bram32 :: 'Signal' System ('Unsigned' 5)
---        -> 'Signal' System (Maybe ('Unsigned' 5, 'Clash.Sized.BitVector.Bit'))
---        -> 'Signal' System 'Clash.Sized.BitVector.Bit'
+-- bram32 :: 'Signal' domain ('Unsigned' 5)
+--        -> 'Signal' domain (Maybe ('Unsigned' 5, 'Clash.Sized.BitVector.Bit'))
+--        -> 'Signal' domain 'Clash.Sized.BitVector.Bit'
 -- bram32 clk = 'blockRamPow2' clk ('Clash.Sized.Vector.replicate' d32 1)
 -- @
 --

--- a/src/Clash/Explicit/BlockRam/File.hs
+++ b/src/Clash/Explicit/BlockRam/File.hs
@@ -33,11 +33,11 @@ For example, a data file @memory.bin@ containing the 9-bit unsigned number
 We can instantiate a BlockRAM using the content of the above file like so:
 
 @
-topEntity
-  :: Clock  System Source
-  -> Signal System (Unsigned 3)
-  -> Signal System (Unsigned 9)
-topEntity clk rd = 'Clash.Class.BitPack.unpack' '<$>' 'blockRamFile' clk d7 \"memory.bin\" rd (signal Nothing)
+f
+  :: Clock  domain gated
+  -> Signal domain (Unsigned 3)
+  -> Signal domain (Unsigned 9)
+f clk rd = 'Clash.Class.BitPack.unpack' '<$>' 'blockRamFile' clk d7 \"memory.bin\" rd (signal Nothing)
 @
 
 In the example above, we basically treat the BlockRAM as an synchronous ROM.
@@ -45,7 +45,7 @@ We can see that it works as expected:
 
 @
 __>>> import qualified Data.List as L__
-__>>> L.tail $ sampleN 4 $ topEntity systemClockGen (fromList [3..5])__
+__>>> L.tail $ sampleN 4 $ f systemClockGen (fromList [3..5])__
 [10,11,12]
 @
 
@@ -53,18 +53,18 @@ However, we can also interpret the same data as a tuple of a 6-bit unsigned
 number, and a 3-bit signed number:
 
 @
-topEntity2
-  :: Clock  System Source
-  -> Signal System (Unsigned 3)
-  -> Signal System (Unsigned 6,Signed 3)
-topEntity2 clk rd = 'Clash.Class.BitPack.unpack' '<$>' 'blockRamFile' clk d7 \"memory.bin\" rd (signal Nothing)
+g
+  :: Clock  domain Source
+  -> Signal domain (Unsigned 3)
+  -> Signal domain (Unsigned 6,Signed 3)
+g clk rd = 'Clash.Class.BitPack.unpack' '<$>' 'blockRamFile' clk d7 \"memory.bin\" rd (signal Nothing)
 @
 
 And then we would see:
 
 @
 __>>> import qualified Data.List as L__
-__>>> L.tail $ sampleN 4 $ topEntity2 systemClockGen (fromList [3..5])__
+__>>> L.tail $ sampleN 4 $ g systemClockGen (fromList [3..5])__
 [(1,2),(1,3)(1,-4)]
 @
 

--- a/src/Clash/Explicit/Mealy.hs
+++ b/src/Clash/Explicit/Mealy.hs
@@ -27,12 +27,12 @@ import Clash.Explicit.Signal (Bundle (..), Clock, Reset, Signal, register)
 >>> import Clash.Explicit.Prelude
 >>> import qualified Data.List as L
 >>> :{
-let mac s (x,y) = (s',s)
+let macT s (x,y) = (s',s)
       where
         s' = x * y + s
 :}
 
->>> let topEntity clk rst = mealy clk rst mac 0
+>>> let mac clk rst = mealy clk rst macT 0
 -}
 
 -- | Create a synchronous function from a combinational function describing
@@ -41,22 +41,23 @@ let mac s (x,y) = (s',s)
 -- @
 -- import qualified Data.List as L
 --
--- mac :: Int        -- Current state
---     -> (Int,Int)  -- Input
---     -> (Int,Int)  -- (Updated state, output)
--- mac s (x,y) = (s',s)
+-- macT
+--   :: Int        -- Current state
+--   -> (Int,Int)  -- Input
+--   -> (Int,Int)  -- (Updated state, output)
+-- macT s (x,y) = (s',s)
 --   where
 --     s' = x * y + s
 --
--- topEntity
---   :: 'Clock' System Source
---   -> 'Reset' System Asynchronous
---   -> 'Signal' System (Int, Int)
---   -> 'Signal' System Int
--- topEntity clk rst = 'mealy' clk rst mac 0
+-- mac
+--   :: 'Clock' domain Source
+--   -> 'Reset' domain Asynchronous
+--   -> 'Signal' domain (Int, Int)
+--   -> 'Signal' domain Int
+-- mac clk rst = 'mealy' clk rst macT 0
 -- @
 --
--- >>> simulate (topEntity systemClockGen systemResetGen) [(1,1),(2,2),(3,3),(4,4)]
+-- >>> simulate (mac systemClockGen systemResetGen) [(1,1),(2,2),(3,3),(4,4)]
 -- [0,1,5,14...
 -- ...
 --

--- a/src/Clash/Explicit/Moore.hs
+++ b/src/Clash/Explicit/Moore.hs
@@ -27,28 +27,29 @@ import Clash.Explicit.Signal (Bundle (..), Clock, Reset, Signal, register)
 {- $setup
 >>> :set -XDataKinds -XTypeApplications
 >>> import Clash.Explicit.Prelude
->>> let mac s (x,y) = x * y + s
->>> let topEntity clk rst = moore clk rst mac id 0
+>>> let macT s (x,y) = x * y + s
+>>> let mac clk rst = moore clk rst macT id 0
 -}
 
 -- | Create a synchronous function from a combinational function describing
 -- a moore machine
 --
 -- @
--- mac :: Int        -- Current state
---     -> (Int,Int)  -- Input
---     -> (Int,Int)  -- Updated state
--- mac s (x,y) = x * y + s
+-- macT
+--   :: Int        -- Current state
+--   -> (Int,Int)  -- Input
+--   -> (Int,Int)  -- Updated state
+-- macT s (x,y) = x * y + s
 --
--- topEntity
---   :: 'Clock' System Source
---   -> 'Reset' System Asynchronous
---   -> 'Signal' System (Int, Int)
---   -> 'Signal' System Int
--- topEntity clk rst = 'moore' clk rst mac id 0
+-- mac
+--   :: 'Clock' mac Source
+--   -> 'Reset' mac Asynchronous
+--   -> 'Signal' mac (Int, Int)
+--   -> 'Signal' mac Int
+-- mac clk rst = 'moore' clk rst macT id 0
 -- @
 --
--- >>> simulate (topEntity systemClockGen systemResetGen) [(1,1),(2,2),(3,3),(4,4)]
+-- >>> simulate (mac systemClockGen systemResetGen) [(1,1),(2,2),(3,3),(4,4)]
 -- [0,1,5,14...
 -- ...
 --

--- a/src/Clash/Explicit/ROM/File.hs
+++ b/src/Clash/Explicit/ROM/File.hs
@@ -33,18 +33,18 @@ We can instantiate a synchronous ROM using the content of the above file like
 so:
 
 @
-topEntity
-  :: Clock  System Source
-  -> Signal System (Unsigned 3)
-  -> Signal System (Unsigned 9)
-topEntity clk rd = 'Clash.Class.BitPack.unpack' '<$>' 'romFile' clk d7 \"memory.bin\" rd
+f
+  :: Clock  domain gated
+  -> Signal domain (Unsigned 3)
+  -> Signal domain (Unsigned 9)
+f clk rd = 'Clash.Class.BitPack.unpack' '<$>' 'romFile' clk d7 \"memory.bin\" rd
 @
 
 And see that it works as expected:
 
 @
 __>>> import qualified Data.List as L__
-__>>> L.tail $ sampleN 4 $ topEntity systemClockGen (fromList [3..5])__
+__>>> L.tail $ sampleN 4 $ f systemClockGen (fromList [3..5])__
 [10,11,12]
 @
 
@@ -52,18 +52,18 @@ However, we can also interpret the same data as a tuple of a 6-bit unsigned
 number, and a 3-bit signed number:
 
 @
-topEntity2
-  :: Clock  System Source
-  -> Signal System (Unsigned 3)
-  -> Signal System (Unsigned 6,Signed 3)
-topEntity2 clk rd = 'Clash.Class.BitPack.unpack' '<$>' 'romFile' clk d7 \"memory.bin\" rd
+g
+  :: Clock  domain Source
+  -> Signal domain (Unsigned 3)
+  -> Signal domain (Unsigned 6,Signed 3)
+g clk rd = 'Clash.Class.BitPack.unpack' '<$>' 'romFile' clk d7 \"memory.bin\" rd
 @
 
 And then we would see:
 
 @
 __>>> import qualified Data.List as L__
-__>>> L.tail $ sampleN 4 $ topEntity2 systemClockGen (fromList [3..5])__
+__>>> L.tail $ sampleN 4 $ g systemClockGen (fromList [3..5])__
 [(1,2),(1,3)(1,-4)]
 @
 -}

--- a/src/Clash/Explicit/Signal.hs
+++ b/src/Clash/Explicit/Signal.hs
@@ -34,7 +34,7 @@ never create a clock that goes any faster!
 
 === Explicit clocks and resets, and meta-stability #metastability#
 
-When <Clash-Signal.html#implicitclockandreset clocks and resets are implicitly routed>
+When <Clash-Signal.html#hiddenclockandreset clocks and resets are implicitly routed>
 using the mechanisms provided by the __clash-prelude__, then clocks and resets
 are also implicitly unique.
 
@@ -252,12 +252,13 @@ systemClockGen = clockGen
 -- topEntity = concat
 --
 -- testBench :: Signal System Bool
--- testBench = done'
+-- testBench = done
 --   where
 --     testInput      = pure ((1 :> 2 :> 3 :> Nil) :> (4 :> 5 :> 6 :> Nil) :> Nil)
 --     expectedOutput = outputVerifier ((1:>2:>3:>4:>5:>6:>Nil):>Nil)
---     done           = expectedOutput (topEntity <$> testInput)
---     done'          = withClockReset ('tbSystemClockGen' (not <\$\> done')) systemResetGen done
+--     done           = exposeClockReset (expectedOutput (topEntity <$> testInput)) clk rst
+--     clk            = 'tbSystemClockGen' (not <\$\> done)
+--     rst            = systemResetGen
 -- @
 tbSystemClockGen
   :: Signal System Bool
@@ -275,12 +276,13 @@ tbSystemClockGen = tbClockGen
 -- topEntity = concat
 --
 -- testBench :: Signal System Bool
--- testBench = done'
+-- testBench = done
 --   where
 --     testInput      = pure ((1 :> 2 :> 3 :> Nil) :> (4 :> 5 :> 6 :> Nil) :> Nil)
 --     expectedOutput = outputVerifier ((1:>2:>3:>4:>5:>6:>Nil):>Nil)
---     done           = expectedOutput (topEntity <$> testInput)
---     done'          = withClockReset (tbSystemClockGen (not <\$\> done')) 'systemResetGen' done
+--     done           = exposeClockReset (expectedOutput (topEntity <$> testInput)) clk rst
+--     clk            = tbSystemClockGen (not <\$\> done)
+--     rst            = 'systemResetGen'
 -- @
 systemResetGen :: Reset System 'Asynchronous
 systemResetGen = asyncResetGen
@@ -313,7 +315,7 @@ systemResetGen = asyncResetGen
 -- topEntity clk rst key1 =
 --     let  (pllOut,pllStable) = altpll (SSymbol @ "altpll50") clk rst
 --          rstSync            = 'resetSynchronizer' pllOut (unsafeToAsyncReset pllStable)
---     in   withClockReset pllOut rstSync leds
+--     in   exposeClockReset leds pllOut rstSync
 --   where
 --     key1R  = isRising 1 key1
 --     leds   = mealy blinkerT (1,False,0) key1R

--- a/src/Clash/Intel/ClockGen.hs
+++ b/src/Clash/Intel/ClockGen.hs
@@ -6,8 +6,9 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 PLL and other clock-related components for Intel (Altera) FPGAs
 -}
 
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE GADTs     #-}
+{-# LANGUAGE DataKinds      #-}
+{-# LANGUAGE ExplicitForAll #-}
+{-# LANGUAGE GADTs          #-}
 module Clash.Intel.ClockGen where
 
 import Clash.Promoted.Symbol
@@ -23,8 +24,18 @@ import Unsafe.Coerce
 -- * 1 output clock
 -- * a reset port
 -- * a locked port
+--
+-- You must use type applications to specify the output clock domain, e.g.:
+--
+-- @
+-- type Dom100MHz = Dom \"A\" 10000
+--
+-- -- outputs a clock running at 100 MHz
+-- altpll @@Dom100MHz (SSymbol @@"altpll50to100") clk50 rst
+-- @
 altpll
-  :: SSymbol name
+  :: forall pllOut pllIn name
+   . SSymbol name
   -- ^ Name of the component, must correspond to the name entered in the QSys
   -- dialog.
   --
@@ -50,8 +61,18 @@ altpll _ clk (Async rst) = (unsafeCoerce (clockGate clk rst), unsafeCoerce rst)
 -- * 1 output clock
 -- * a reset port
 -- * a locked port
+--
+-- You must use type applications to specify the output clock domain, e.g.:
+--
+-- @
+-- type Dom100MHz = Dom \"A\" 10000
+--
+-- -- outputs a clock running at 100 MHz
+-- alteraPll @@Dom100MHz (SSymbol @@"alteraPll50to100") clk50 rst
+-- @
 alteraPll
-  :: SSymbol name
+  :: forall pllOut pllIn name
+   . SSymbol name
   -- ^ Name of the component, must correspond to the name entered in the QSys
   -- dialog.
   --

--- a/src/Clash/Prelude.hs
+++ b/src/Clash/Prelude.hs
@@ -74,10 +74,6 @@ module Clash.Prelude
   , windowD
   , isRising
   , isFalling
-    -- * Testbench functions
-  , assert
-  , stimuliGenerator
-  , outputVerifier
     -- * Exported modules
     -- ** Synchronous signals
   , module Clash.Signal
@@ -152,7 +148,6 @@ import           Clash.Prelude.BlockRam.File
 import           Clash.Prelude.DataFlow
 import           Clash.Prelude.ROM.File
 import           Clash.Prelude.Safe
-import           Clash.Prelude.Testbench
 import           Clash.Promoted.Nat
 import           Clash.Promoted.Nat.TH
 import           Clash.Promoted.Nat.Literals

--- a/src/Clash/Prelude.hs
+++ b/src/Clash/Prelude.hs
@@ -168,9 +168,9 @@ import           Clash.Signal.Delayed
 import           Clash.XException
 
 {- $setup
->>> :set -XDataKinds
->>> let window4  = window  :: HasClockReset domain gated synchronous => Signal domain Int -> Vec 4 (Signal domain Int)
->>> let windowD3 = windowD :: HasClockReset domain gated synchronous => Signal domain Int -> Vec 3 (Signal domain Int)
+>>> :set -XDataKinds -XFlexibleContexts
+>>> let window4  = window  :: HiddenClockReset domain => Signal domain Int -> Vec 4 (Signal domain Int)
+>>> let windowD3 = windowD :: HiddenClockReset domain => Signal domain Int -> Vec 3 (Signal domain Int)
 -}
 
 {- $hiding
@@ -186,7 +186,7 @@ It instead exports the identically named functions defined in terms of
 
 -- | Give a window over a 'Signal'
 --
--- > window4 :: HasClockReset domain gated synchronous
+-- > window4 :: HiddenClockReset domain
 -- >         => Signal domain Int -> Vec 4 (Signal domain Int)
 -- > window4 = window
 --
@@ -194,15 +194,15 @@ It instead exports the identically named functions defined in terms of
 -- [<1,0,0,0>,<2,1,0,0>,<3,2,1,0>,<4,3,2,1>,<5,4,3,2>...
 -- ...
 window
-  :: (KnownNat n, Default a, HasClockReset domain gated synchronous)
+  :: (KnownNat n, Default a, HiddenClockReset domain)
   => Signal domain a                -- ^ Signal to create a window over
   -> Vec (n + 1) (Signal domain a)  -- ^ Window of at least size 1
-window = E.window hasClock hasReset
+window = hideClockReset E.window
 {-# INLINE window #-}
 
 -- | Give a delayed window over a 'Signal'
 --
--- > windowD3 :: HasClockReset domain gated synchronous
+-- > windowD3 :: HiddenClockReset domain
 -- >          => Signal domain Int -> Vec 3 (Signal domain Int)
 -- > windowD3 = windowD
 --
@@ -210,8 +210,8 @@ window = E.window hasClock hasReset
 -- [<0,0,0>,<1,0,0>,<2,1,0>,<3,2,1>,<4,3,2>...
 -- ...
 windowD
-  :: (KnownNat n, Default a, HasClockReset domain gated synchronous)
+  :: (KnownNat n, Default a, HiddenClockReset domain)
   => Signal domain a               -- ^ Signal to create a window over
   -> Vec (n + 1) (Signal domain a) -- ^ Window of at least size 1
-windowD = E.windowD hasClock hasReset
+windowD = hideClockReset E.windowD
 {-# INLINE windowD #-}

--- a/src/Clash/Prelude/RAM.hs
+++ b/src/Clash/Prelude/RAM.hs
@@ -46,7 +46,7 @@ import           Clash.Sized.Unsigned (Unsigned)
 -- * See "Clash.Prelude.BlockRam#usingrams" for more information on how to use a
 -- RAM.
 asyncRam
-  :: (Enum addr, HasClock domain gated, HasCallStack)
+  :: (Enum addr, HiddenClock domain, HasCallStack)
   => SNat n
   -- ^ Size @n@ of the RAM
   -> Signal domain addr
@@ -56,7 +56,7 @@ asyncRam
   -> Signal domain a
    -- ^ Value of the @RAM@ at address @r@
 asyncRam = \sz rd wrM -> withFrozenCallStack
-  (E.asyncRam hasClock hasClock sz rd wrM)
+  (hideClock (\clk -> E.asyncRam clk clk sz rd wrM))
 {-# INLINE asyncRam #-}
 
 -- | Create a RAM with space for 2^@n@ elements
@@ -68,7 +68,7 @@ asyncRam = \sz rd wrM -> withFrozenCallStack
 -- * See "Clash.Prelude.BlockRam#usingrams" for more information on how to use a
 -- RAM.
 asyncRamPow2
-  :: (KnownNat n, HasClock domain gated, HasCallStack)
+  :: (KnownNat n, HiddenClock domain, HasCallStack)
   => Signal domain (Unsigned n)
   -- ^ Read address @r@
   -> Signal domain (Maybe (Unsigned n, a))
@@ -76,5 +76,5 @@ asyncRamPow2
   -> Signal domain a
   -- ^ Value of the @RAM@ at address @r@
 asyncRamPow2 = \rd wrM -> withFrozenCallStack
-  (E.asyncRamPow2 hasClock hasClock rd wrM)
+  (hideClock (\clk -> E.asyncRamPow2 clk clk rd wrM))
 {-# INLINE asyncRamPow2 #-}

--- a/src/Clash/Prelude/ROM.hs
+++ b/src/Clash/Prelude/ROM.hs
@@ -7,9 +7,10 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 ROMs
 -}
 
-{-# LANGUAGE DataKinds     #-}
-{-# LANGUAGE MagicHash     #-}
-{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE DataKinds        #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE MagicHash        #-}
+{-# LANGUAGE TypeOperators    #-}
 
 {-# LANGUAGE Safe #-}
 
@@ -90,13 +91,13 @@ asyncRom# content rd = arr ! rd
 -- * See "Clash.Sized.Fixed#creatingdatafiles" and "Clash.Prelude.BlockRam#usingrams"
 -- for ideas on how to use ROMs and RAMs
 rom
-  :: (KnownNat n, KnownNat m, HasClock domain gated)
+  :: (KnownNat n, KnownNat m, HiddenClock domain)
   => Vec n a               -- ^ ROM content
                            --
                            -- __NB:__ must be a constant
   -> Signal domain (Unsigned m)   -- ^ Read address @rd@
   -> Signal domain a              -- ^ The value of the ROM at address @rd@
-rom = E.rom hasClock
+rom = hideClock E.rom
 {-# INLINE rom #-}
 
 -- | A ROM with a synchronous read port, with space for 2^@n@ elements
@@ -109,11 +110,11 @@ rom = E.rom hasClock
 -- * See "Clash.Sized.Fixed#creatingdatafiles" and "Clash.Prelude.BlockRam#usingrams"
 -- for ideas on how to use ROMs and RAMs
 romPow2
-  :: (KnownNat n, HasClock domain gated)
+  :: (KnownNat n, HiddenClock domain)
   => Vec (2^n) a         -- ^ ROM content
                          --
                          -- __NB:__ must be a constant
   -> Signal domain (Unsigned n) -- ^ Read address @rd@
   -> Signal domain a            -- ^ The value of the ROM at address @rd@
-romPow2 = E.romPow2 hasClock
+romPow2 = hideClock E.romPow2
 {-# INLINE romPow2 #-}

--- a/src/Clash/Prelude/ROM/File.hs
+++ b/src/Clash/Prelude/ROM/File.hs
@@ -33,15 +33,15 @@ We can instantiate a synchronous ROM using the content of the above file like
 so:
 
 @
-topEntity :: Signal (Unsigned 3) -> Signal (Unsigned 9)
-topEntity rd = 'Clash.Class.BitPack.unpack' '<$>' 'romFile' d7 \"memory.bin\" rd
+f :: HiddenClock domain => Signal domain (Unsigned 3) -> Signal domain (Unsigned 9)
+f rd = 'Clash.Class.BitPack.unpack' '<$>' 'romFile' d7 \"memory.bin\" rd
 @
 
 And see that it works as expected:
 
 @
 __>>> import qualified Data.List as L__
-__>>> L.tail $ sampleN 4 $ topEntity (fromList [3..5])__
+__>>> L.tail $ sampleN 4 $ f (fromList [3..5])__
 [10,11,12]
 @
 
@@ -49,15 +49,15 @@ However, we can also interpret the same data as a tuple of a 6-bit unsigned
 number, and a 3-bit signed number:
 
 @
-topEntity2 :: Signal (Unsigned 3) -> Signal (Unsigned 6,Signed 3)
-topEntity2 rd = 'Clash.Class.BitPack.unpack' '<$>' 'romFile' d7 \"memory.bin\" rd
+g :: HiddenClock domain => Signal domain (Unsigned 3) -> Signal domain (Unsigned 6,Signed 3)
+g rd = 'Clash.Class.BitPack.unpack' '<$>' 'romFile' d7 \"memory.bin\" rd
 @
 
 And then we would see:
 
 @
 __>>> import qualified Data.List as L__
-__>>> L.tail $ sampleN 4 $ topEntity2 (fromList [3..5])__
+__>>> L.tail $ sampleN 4 $ g (fromList [3..5])__
 [(1,2),(1,3)(1,-4)]
 @
 -}
@@ -258,13 +258,13 @@ asyncRomFile# sz file = (content !) -- Leave "(content !)" eta-reduced, see
 -- * See "Clash.Sized.Fixed#creatingdatafiles" for ideas on how to create your
 -- own data files.
 romFile
-  :: (KnownNat m, KnownNat n, HasClock domain gated)
+  :: (KnownNat m, KnownNat n, HiddenClock domain)
   => SNat n               -- ^ Size of the ROM
   -> FilePath             -- ^ File describing the content of the ROM
   -> Signal domain (Unsigned n)  -- ^ Read address @rd@
   -> Signal domain (BitVector m)
   -- ^ The value of the ROM at address @rd@ from the previous clock cycle
-romFile = E.romFile hasClock
+romFile = hideClock E.romFile
 {-# INLINE romFile #-}
 
 -- | A ROM with a synchronous read port, with space for 2^@n@ elements
@@ -291,11 +291,11 @@ romFile = E.romFile hasClock
 -- * See "Clash.Sized.Fixed#creatingdatafiles" for ideas on how to create your
 -- own data files.
 romFilePow2
-  :: forall n m domain gated
-   . (KnownNat m, KnownNat n, HasClock domain gated)
+  :: forall n m domain
+   . (KnownNat m, KnownNat n, HiddenClock domain)
   => FilePath                    -- ^ File describing the content of the ROM
   -> Signal domain (Unsigned n)  -- ^ Read address @rd@
   -> Signal domain (BitVector m)
   -- ^ The value of the ROM at address @rd@ from the previous clock cycle
-romFilePow2 = E.romFilePow2 hasClock
+romFilePow2 = hideClock E.romFilePow2
 {-# INLINE romFilePow2 #-}

--- a/src/Clash/Prelude/Safe.hs
+++ b/src/Clash/Prelude/Safe.hs
@@ -148,7 +148,7 @@ import           Clash.Signal.Delayed
 import           Clash.XException
 
 {- $setup
->>> :set -XTypeApplications
+>>> :set -XFlexibleContexts -XTypeApplications
 >>> let rP = registerB (8,8)
 -}
 
@@ -164,39 +164,39 @@ It instead exports the identically named functions defined in terms of
 
 -- | Create a 'register' function for product-type like signals (e.g. '(Signal a, Signal b)')
 --
--- > rP :: HasClockAndReset System gated synchronous
--- >    => (Signal System Int, Signal System Int)
--- >    -> (Signal System Int, Signal System Int)
+-- > rP :: HiddenClockReset domain
+-- >    => (Signal domain Int, Signal domain Int)
+-- >    -> (Signal domain Int, Signal domain Int)
 -- > rP = registerB (8,8)
 --
 -- >>> simulateB rP [(1,1),(2,2),(3,3)] :: [(Int,Int)]
 -- [(8,8),(1,1),(2,2),(3,3)...
 -- ...
 registerB
-  :: (HasClockReset domain gated synchronous, Bundle a)
+  :: (HiddenClockReset domain, Bundle a)
   => a
   -> Unbundled domain a
   -> Unbundled domain a
-registerB = E.registerB hasClock hasReset
+registerB = hideClockReset E.registerB
 infixr 3 `registerB`
 {-# INLINE registerB #-}
 
 -- | Give a pulse when the 'Signal' goes from 'minBound' to 'maxBound'
 isRising
-  :: (HasClockReset domain gated synchronous, Bounded a, Eq a)
+  :: (HiddenClockReset domain, Bounded a, Eq a)
   => a -- ^ Starting value
   -> Signal domain a
   -> Signal domain Bool
-isRising = E.isRising hasClock hasReset
+isRising = hideClockReset E.isRising
 {-# INLINE isRising #-}
 
 -- | Give a pulse when the 'Signal' goes from 'maxBound' to 'minBound'
 isFalling
-  :: (HasClockReset domain gated synchronous, Bounded a, Eq a)
+  :: (HiddenClockReset domain, Bounded a, Eq a)
   => a -- ^ Starting value
   -> Signal domain a
   -> Signal domain Bool
-isFalling = E.isFalling hasClock hasReset
+isFalling = hideClockReset E.isFalling
 {-# INLINE isFalling #-}
 
 -- | Give a pulse every @n@ clock cycles. This is a useful helper function when
@@ -217,10 +217,10 @@ isFalling = E.isFalling hasClock hasReset
 -- counter = 'Clash.Signal.regEn' 0 ('riseEvery' ('SNat' :: 'SNat' 10000000)) (counter + 1)
 -- @
 riseEvery
-  :: HasClockReset domain gated synchronous
+  :: HiddenClockReset domain
   => SNat n
   -> Signal domain Bool
-riseEvery = E.riseEvery hasClock hasReset
+riseEvery = hideClockReset E.riseEvery
 {-# INLINE riseEvery #-}
 
 -- | Oscillate a @'Bool'@ for a given number of cycles. This is a convenient
@@ -245,9 +245,9 @@ riseEvery = E.riseEvery hasClock hasReset
 -- >>> sample' (oscillate False d1) == sample' osc'
 -- True
 oscillate
-  :: HasClockReset domain gated synchronous
+  :: HiddenClockReset domain
   => Bool
   -> SNat n
   -> Signal domain Bool
-oscillate = E.oscillate hasClock hasReset
+oscillate = hideClockReset E.oscillate
 {-# INLINE oscillate #-}

--- a/src/Clash/Prelude/Testbench.hs
+++ b/src/Clash/Prelude/Testbench.hs
@@ -5,6 +5,7 @@ License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
+{-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 {-# LANGUAGE Unsafe #-}
@@ -23,7 +24,7 @@ import GHC.TypeLits                       (KnownNat)
 
 import qualified Clash.Explicit.Testbench as E
 import           Clash.Signal
-  (HasClockReset, Signal, hasClock, hasReset)
+  (HiddenClockReset, Signal, hideClockReset)
 import Clash.Sized.Vector                 (Vec)
 import Clash.XException                   (ShowX)
 
@@ -42,13 +43,13 @@ import Clash.XException                   (ShowX)
 --
 -- __NB__: This function /can/ be used in synthesizable designs.
 assert
-  :: (Eq a,ShowX a,HasClockReset domain gated synchronous)
+  :: (Eq a,ShowX a,HiddenClockReset domain)
   => String   -- ^ Additional message
   -> Signal domain a -- ^ Checked value
   -> Signal domain a -- ^ Expected value
   -> Signal domain b -- ^ Return value
   -> Signal domain b
-assert = E.assert hasClock hasReset
+assert = hideClockReset E.assert
 {-# INLINE assert #-}
 
 -- | To be used as one of the functions to create the \"magical\" 'testInput'
@@ -59,7 +60,7 @@ assert = E.assert hasClock hasReset
 --
 -- @
 -- testInput
---   :: HasClockAndReset domain gated synchronous
+--   :: HiddenClockReset domain
 --   => 'Signal' domain Int
 -- testInput = 'stimuliGenerator' $('Clash.Sized.Vector.listToVecTH' [(1::Int),3..21])
 -- @
@@ -67,10 +68,10 @@ assert = E.assert hasClock hasReset
 -- >>> sampleN 13 testInput
 -- [1,3,5,7,9,11,13,15,17,19,21,21,21]
 stimuliGenerator
-  :: (KnownNat l, HasClockReset domain gated synchronous)
+  :: (KnownNat l, HiddenClockReset domain)
   => Vec l a  -- ^ Samples to generate
   -> Signal domain a -- ^ Signal of given samples
-stimuliGenerator = E.stimuliGenerator hasClock hasReset
+stimuliGenerator = hideClockReset E.stimuliGenerator
 {-# INLINE stimuliGenerator #-}
 
 -- | To be used as one of the functions to generate the \"magical\" 'expectedOutput'
@@ -81,7 +82,7 @@ stimuliGenerator = E.stimuliGenerator hasClock hasReset
 --
 -- @
 -- expectedOutput
---   :: HasClockAndReset domain gated synchronous
+--   :: HiddenClockReset domain
 --   -> 'Signal' domain Int -> 'Signal' domain Bool
 -- expectedOutput = 'outputVerifier' $('Clash.Sized.Vector.listToVecTH' ([70,99,2,3,4,5,7,8,9,10]::[Int]))
 -- @
@@ -108,9 +109,9 @@ stimuliGenerator = E.stimuliGenerator hasClock hasReset
 -- expected value: 10, not equal to actual value: 9
 -- ,False,True,True]
 outputVerifier
-  :: (KnownNat l, Eq a, ShowX a, HasClockReset domain gated synchronous)
+  :: (KnownNat l, Eq a, ShowX a, HiddenClockReset domain)
   => Vec l a     -- ^ Samples to compare with
   -> Signal domain a    -- ^ Signal to verify
   -> Signal domain Bool -- ^ Indicator that all samples are verified
-outputVerifier = E.outputVerifier hasClock hasReset
+outputVerifier = hideClockReset E.outputVerifier
 {-# INLINE outputVerifier #-}

--- a/src/Clash/Signal.hs
+++ b/src/Clash/Signal.hs
@@ -33,13 +33,14 @@ so do __not__ do that!
 never create a clock that goes any faster!
 -}
 
-{-# LANGUAGE ConstraintKinds #-}
-{-# LANGUAGE DataKinds       #-}
-{-# LANGUAGE GADTs           #-}
-{-# LANGUAGE ImplicitParams  #-}
-{-# LANGUAGE MagicHash       #-}
-{-# LANGUAGE RankNTypes      #-}
-{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ConstraintKinds     #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE MagicHash           #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
 
 {-# LANGUAGE Trustworthy #-}
 
@@ -62,20 +63,23 @@ module Clash.Signal
   , fromSyncReset
   , unsafeToSyncReset
   , resetSynchronizer
-    -- * Implicit routing of clocks and resets
-    -- $implicitclockandreset
+    -- * Hidden clocks and resets
+    -- $hiddenclockandreset
 
-    -- ** Implicit clock
-  , HasClock
-  , hasClock
-  , withClock
-    -- ** Implicit reset
-  , HasReset
-  , hasReset
-  , withReset
-    -- ** Implicit clock and reset
-  , HasClockReset
-  , withClockReset
+    -- ** Hidden clock
+  , SomeClock
+  , HiddenClock
+  , hideClock
+  , exposeClock
+    -- ** Hidden reset
+  , SomeReset
+  , HiddenReset
+  , hideReset
+  , exposeReset
+    -- ** Hidden clock and reset
+  , HiddenClockReset
+  , hideClockReset
+  , exposeClockReset
   , SystemClockReset
     -- * Basic circuit functions
   , delay
@@ -124,6 +128,7 @@ import           GHC.Stack             (HasCallStack, withFrozenCallStack)
 import           GHC.TypeLits          (KnownNat, KnownSymbol)
 import           Data.Bits             (Bits) -- Haddock only
 import           Data.Maybe            (isJust, fromJust)
+import           Data.Reflection       (Given (..), give)
 import           Test.QuickCheck       (Property, property)
 import           Unsafe.Coerce         (unsafeCoerce)
 
@@ -138,7 +143,7 @@ import           Clash.Signal.Internal hiding
 import qualified Clash.Signal.Internal as S
 
 {- $setup
->>> :set -XTypeApplications
+>>> :set -XFlexibleContexts -XTypeApplications
 >>> import Clash.XException (printX)
 >>> import Control.Applicative (liftA2)
 >>> let oscillate = register False (not <$> oscillate)
@@ -158,74 +163,74 @@ countSometimes = s where
 
 -}
 
--- * Implicit routing of clock and reset signals
+-- * Hidden clock and reset arguments
 
-{- $implicitclockandreset #implicitclockandreset#
+{- $hiddenclockandreset #hiddenclockandreset#
 Clocks and resets are by default implicitly routed to their components. You can
-see from the type of a component whether it has implicitly routed clocks or
-resets:
+see from the type of a component whether it has hidden clock or reset
+arguments:
 
-It has an implicitly routed clock when it has a:
-
-@
-f :: 'HasClock' domain gated => ...
-@
-
-Constraint.
-
-Or it has an implicitly routed reset when it has a:
+It has a hidden clock when it has a:
 
 @
-g :: 'HasReset' domain synchronous => ...
+f :: 'HiddenClock' domain gated => ...
 @
 
 Constraint.
 
-Or it has both an implicitly routed clock and an implicitly routed reset when it
+Or it has a hidden reset when it has a:
+
+@
+g :: 'HiddenReset' domain synchronous => ...
+@
+
+Constraint.
+
+Or it has both a hidden clock argument and a hidden reset argument when it
 has a:
 
 @
-h :: 'HasClockReset' domain gated synchronous => ..
+h :: 'HiddenClockReset' domain gated synchronous => ..
 @
 
 Constraint.
 
-Given a component with an explicit clock and reset port, you can have them
-implicitly routed using 'hasClock' and 'hasReset'. So given a:
+Given a component with an explicit clock and reset arguments, you can turn them
+into hidden arguments using 'hideClock' and 'hideReset'. So given a:
 
 @
 f :: Clock domain gated -> Reset domain synchronous -> Signal domain a -> ...
 @
 
-You have have the clock and reset implicitly routed by:
+You hide the clock and reset arguments by:
 
 @
--- g :: 'HasClockReset' domain gated synchronous => Signal domain a -> ...
-g = f 'hasClock' 'hasReset'
+-- g :: 'HiddenClockReset' domain gated synchronous => Signal domain a -> ...
+g = 'hideClockReset' f
 @
 
-=== Assigning explicit clock and reset arguments to implicit clocks and resets
+=== Assigning explicit clock and reset arguments to hidden clocks and resets
 
 Given a component:
 
 @
-f :: HasClockReset domain gated synchronous
+f :: HiddenClockReset domain gated synchronous
   => Signal domain Int
   -> Signal domain Int
 @
 
-which has an implicitly routed clock and implicitly routed clock, we can use
-it in a function with explicit clock and reset arguments like so:
+which has hidden clock and routed reset arguments, we expose those hidden
+arguments so that we can explicitly apply them:
 
 @
 -- g :: Clock domain gated -> Reset domain synchronous -> Signal domain Int -> Signal domain Int
-g clk rst = 'withClockReset' clk rst f
+g = 'exposeClockReset' f
 @
 
-Similarly, there are 'withClock' and 'withReset' to connect just implicit clocks
-or just implicit resets respectively.
+Similarly, there are 'exposeClock' and 'exposeReset' to connect just expose
+the hidden clock or the hidden reset argument.
 
-You will need to explicitly apply clocks and resets when you want to using
+You will need to explicitly apply clocks and resets when you want to use
 components such as PPLs and 'resetSynchronizer':
 
 @
@@ -237,168 +242,86 @@ topEntity
 topEntity clk rst =
   let (pllOut,pllStable) = 'Clash.Intel.ClockGen.altpll' (SSymbol \@\"altpll50\") clk rst
       rstSync            = 'resetSynchronizer' pllOut ('unsafeToAsyncReset' pllStable)
-  in  'withClockReset' pllOut rstSync f
+  in  'exposeClockReset' f pllOut rstSync
 @
 
-=== Implicit parameters
-
-__TL;DR__ do __not__ use 'HasClock', 'HasReset', 'HasClockReset', 'hasClock',
-'hasReset', or 'SystemClockReset', when you have multiple /clock/ (or /reset/)
-domains.
-
-__Want to know:__
-
-Under the hood, Clash uses
-<https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/glasgow_exts.html#implicit-parameters Implicit Parameters>
-to implicitly route the clock and reset.
-
-This means that you cannot use the 'hasClock' and 'hasReset' functions when you
-are working with multiple /clock/ (and /reset/) domains. Because, given a:
-
-@
-f :: Clock domainA gatedA -> Clock domainB gatedB -> Signal domainA a -> Signal domainB b -> ..
-@
-
-and using 'hasClock' as we did above, we will get:
-
-@
--- g :: HasClock domainB gatedB => Signal domainB a -> Signal domainB b -> ...
-g = f hasClock hasClock
-@
-
-That is, sub-components of /f/ will be synchronized to the same clock, where
-the idea was probably to synchronize them to different clocks.
-
-Trying to give different implicit clocks will also not work:
-
-@
-h :: forall domainA domainB gatedA gatedB a b
-   . (HasClock domainA gatedA, HasClock domainB gatedB)
-  => Signal domainA a -> Signal domainB b -> ...
-h = f (hasClock \@domainA) (hasClock \@domainB)
-@
-
-as it will result in a type error.
-
-In case you want to have implicitly routed clocks and resets for
-multi-/clock/ (and -/reset/) domain designs you will have to use to use
-<https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/glasgow_exts.html#implicit-parameters Implicit Parameters>
-directly:
-
-@
--- k :: (?clkB::Clock domainB gatedB,?clkA::Clock domainA gatedA)
---   => Signal domainA a -> Signal domainB b -> ...
-k = f ?clkA ?clkB
-@
-
-Note that you __cannot__ use /any/ of the functions that mention 'HasClock',
-'HasReset', or 'HasClockReset' constraints. So when you want to assign clock
-or reset arguments to your self-rolled implicit clocks and resets you will need
-to use the
-
-@
-let ?clkA = ...
-in  k
-@
-
-notation for binding
-<https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/glasgow_exts.html#implicit-parameters Implicit Parameters>.
 -}
 
--- | A /constraint/ that indicates the component needs a 'Clock'
+-- | A clock that is polymorphic in whether it's gated or not
+data SomeClock domain where
+  SomeClock :: Clock domain gated -> SomeClock domain
+
+-- | A /constraint/ that indicates the component has a hidden 'Clock'
 --
--- <Clash-Signal.html#implicitclockandreset Click here to read more about implicit clocks and resets>
-type HasClock domain gated       = (?clk :: Clock domain gated)
+-- <Clash-Signal.html#hiddenclockandreset Click here to read more about hidden clocks and resets>
+type HiddenClock domain = Given (SomeClock domain)
+
+-- | A reset that is polymorphic in whether it's synchronous or asynchronous
+data SomeReset domain where
+  SomeReset :: Reset domain synchronous -> SomeReset domain
 
 -- | A /constraint/ that indicates the component needs a 'Reset'
 --
--- <Clash-Signal.html#implicitclockandreset Click here to read more about implicit clocks and resets>
-type HasReset domain synchronous = (?rst :: Reset domain synchronous)
+-- <Clash-Signal.html#hiddenclockandreset Click here to read more about hidden clocks and resets>
+type HiddenReset domain = Given (SomeReset domain)
 
 -- | A /constraint/ that indicates the component needs a 'Clock' and 'Reset'
 --
--- <Clash-Signal.html#implicitclockandreset Click here to read more about implicit clocks and resets>
-type HasClockReset domain gated synchronous =
-  (HasClock domain gated, HasReset domain synchronous)
+-- <Clash-Signal.html#hiddenclockandreset Click here to read more about hidden clocks and resets>
+type HiddenClockReset domain = (HiddenClock domain, HiddenReset domain)
 
--- | For a component with an explicit clock port, implicitly route a clock
--- to that port.
+-- | A /constraint/ that indicates the component needs a 'Clock' and a 'Reset'
+-- belonging to the 'System' domain.
 --
--- So given:
---
--- > f :: Clock domain gated -> Signal domain a -> ...
---
--- You can implicitly route a clock by:
---
--- > g :: HaClock domain gated => Signal domain a -> ...
--- > g = f hasClock
---
--- __NB__ all components with a `HasClock` /constraint/ are connected to
--- the same clock.
---
--- <Clash-Signal.html#implicitclockandreset Click here to read more about implicit clocks and resets>
-hasClock :: HasClock domain gated => Clock domain gated
-hasClock = ?clk
-{-# INLINE hasClock #-}
+-- <Clash-Signal.html#hiddenclockandreset Click here to read more about hidden clocks and resets>
+type SystemClockReset = HiddenClockReset System
 
--- | For a component with an explicit clock port, implicitly route a clock
--- to that port.
+-- | Expose the hidden 'Clock' argument of a component, so it can be applied
+-- explicitly
 --
--- So given:
---
--- > f :: Reset domain synchronous -> Signal domain a -> ...
---
--- You can implicitly route a clock by:
---
--- > g :: HasReset domain synchronous => Signal domain a -> ...
--- > g = f hasReset
---
--- __NB__ all components with a `HasReset` /constraint/ are connected to
--- the same reset.
---
--- <Clash-Signal.html#implicitclockandreset Click here to read more about implicit clocks and resets>
-hasReset :: HasReset domain synchronous => Reset domain synchronous
-hasReset = ?rst
-{-# INLINE hasReset #-}
+-- <Clash-Signal.html#hiddenclockandreset Click here to read more about hidden clocks and resets>
+exposeClock
+  :: (HiddenClock domain => r)
+  -- ^ The component with a hidden clock
+  -> (Clock domain gated -> r)
+  -- ^ The component with its clock argument exposed
+exposeClock = \f clk -> give (SomeClock clk) f
+{-# INLINE exposeClock #-}
 
--- | A /constraint/ that indicates the component needs a normal 'Clock' and
--- an asynchronous 'Reset' belonging to the 'System' domain.
---
--- <Clash-Signal.html#implicitclockandreset Click here to read more about implicit clocks and resets>
-type SystemClockReset = HasClockReset System 'Source 'Asynchronous
-
--- | Explicitly connect a 'Clock' to a component whose clock is implicitly
--- routed
---
--- <Clash-Signal.html#implicitclockandreset Click here to read more about implicit clocks and resets>
-withClock
-  :: Clock domain gated
-  -- ^ The 'Clock' we want to connect
-  -> (HasClock domain gated => r)
-  -- ^ The component with an implicitly routed clock
+-- | Hide the 'Clock' argument of a component, so it can be routed implicitly.
+hideClock
+  :: HiddenClock domain
+  => (forall gated . Clock domain gated -> r)
+  -- ^ Function whose clock argument you want to hide
   -> r
-withClock clk r
-  = let ?clk = clk
-    in  r
+hideClock = \f -> case given of SomeClock clk -> f clk
+{-# INLINE hideClock #-}
 
--- | Explicit connect a 'Reset' to a component whose reset is implicitly
--- routed
+-- | Expose the hidden 'Reset' argument of a component, so it can be applied
+-- explicitly
 --
--- <Clash-Signal.html#implicitclockandreset Click here to read more about implicit clocks and resets>
-withReset
-  :: Reset domain synchronous
-  -- ^ The 'Reset' we want to connect
-  -> (HasReset domain synchronous => r)
-  -- ^ The component with an implicitly routed reset
+-- <Clash-Signal.html#hiddenclockandreset Click here to read more about hidden clocks and resets>
+exposeReset
+  :: (HiddenReset domain => r)
+  -- ^ The component with a hidden reset
+  -> (Reset domain synchronous -> r)
+  -- ^ The component with its reset argument exposed
+exposeReset = \f rst -> give (SomeReset rst) f
+{-# INLINE exposeReset #-}
+
+-- | Hide the 'Reset' argument of a component, so it can be routed implicitly.
+hideReset
+  :: HiddenReset domain
+  => (forall synchronous . Reset domain synchronous -> r)
+  -- ^ Component whose reset argument you want to hide
   -> r
-withReset rst r
-  = let ?rst = rst
-    in  r
+hideReset = \f -> case given of SomeReset rst -> f rst
+{-# INLINE hideReset #-}
 
--- | Explicitly connect a 'Clock' and 'Reset' to a component whose clock and
--- reset are implicitly routed
+-- | Expose the hidden 'Clock' and 'Reset' arguments of a component, so they can
+-- be applied explicitly
 --
--- <Clash-Signal.html#implicitclockandreset Click here to read more about implicit clocks and resets>
+-- <Clash-Signal.html#hiddenclockandreset Click here to read more about hidden clocks and resets>
 --
 -- === __Example__
 --
@@ -407,25 +330,31 @@ withReset rst r
 -- topEntity = concat
 --
 -- testBench :: Signal System Bool
--- testBench = done'
+-- testBench = done
 --   where
 --     testInput      = pure ((1 :> 2 :> 3 :> Nil) :> (4 :> 5 :> 6 :> Nil) :> Nil)
 --     expectedOutput = outputVerifier ((1:>2:>3:>4:>5:>6:>Nil):>Nil)
---     done           = expectedOutput (topEntity <$> testInput)
---     done'          = 'withClockReset' (tbSystemClockGen (not <\$\> done')) systemResetGen done
+--     done           = exposeClockReset (expectedOutput (topEntity <$> testInput)) clk rst
+--     clk            = tbSystemClockGen (not <\$\> done)
+--     rst            = systemResetGen
 -- @
-withClockReset
-  :: Clock domain gated
-  -- ^ The 'Clock' we want to connect
-  -> Reset domain synchronous
-  -- ^ The 'Reset' we want to connect
-  -> (HasClockReset domain gated synchronous => r)
-  -- ^ The component with an implicitly routed clock and reset
+exposeClockReset
+  :: (HiddenClockReset domain => r)
+  -- ^ The component with hidden clock and reset arguments
+  -> (Clock domain gated -> Reset domain synchronous -> r)
+  -- ^ The component with its clock and reset arguments exposed
+exposeClockReset = \f clk rst -> give (SomeReset rst) ((give (SomeClock clk) f))
+{-# INLINE exposeClockReset #-}
+
+-- | Hide the 'Clock' and 'Reset' arguments of a component, so they can be
+-- routed implicitly
+hideClockReset
+  :: HiddenClockReset domain
+  => (forall gated synchronous . Clock domain gated -> Reset domain synchronous -> r)
+  -- ^ Component whose clock and reset argument you want to hide
   -> r
-withClockReset clk rst r
-  = let ?clk = clk
-        ?rst = rst
-    in  r
+hideClockReset = \f -> hideReset (hideClock f)
+{-# INLINE hideClockReset #-}
 
 -- * Basic circuit functions
 
@@ -435,11 +364,11 @@ withClockReset clk rst r
 -- >>> printX (sampleN 3 (delay (fromList [1,2,3,4])))
 -- [X,1,2]
 delay
-  :: (HasClock domain gated, HasCallStack)
+  :: (HiddenClock domain, HasCallStack)
   => Signal domain a
   -- ^ Signal to delay
   -> Signal domain a
-delay = \i -> withFrozenCallStack (delay# ?clk i)
+delay = \i -> withFrozenCallStack (hideClock delay# i)
 {-# INLINE delay #-}
 
 -- | 'register' @i s@ delays the values in 'Signal' @s@ for one cycle, and sets
@@ -448,7 +377,7 @@ delay = \i -> withFrozenCallStack (delay# ?clk i)
 -- >>> sampleN 3 (register 8 (fromList [1,2,3,4]))
 -- [8,1,2]
 register
-  :: (HasClockReset domain gated synchronous, HasCallStack)
+  :: (HiddenClockReset domain, HasCallStack)
   => a
   -- ^ Reset value
   --
@@ -456,7 +385,7 @@ register
   -- reset value when the reset value becomes 'True'
   -> Signal domain a
   -> Signal domain a
-register = \i s -> withFrozenCallStack (register# ?clk ?rst i s)
+register = \i s -> withFrozenCallStack (hideClockReset register# i s)
 {-# INLINE register #-}
 infixr 3 `register`
 
@@ -482,7 +411,7 @@ infixr 3 `register`
 -- >>> sampleN 8 countSometimes
 -- [0,0,1,1,2,2,3,3]
 regMaybe
-  :: (HasClockReset domain gated synchronous, HasCallStack)
+  :: (HiddenClockReset domain, HasCallStack)
   => a
   -- ^ Reset value
   --
@@ -491,7 +420,7 @@ regMaybe
   -> Signal domain (Maybe a)
   -> Signal domain a
 regMaybe = \initial iM -> withFrozenCallStack
-  (register# (clockGate ?clk (fmap isJust iM)) ?rst initial (fmap fromJust iM))
+  (hideClockReset (\clk rst -> register# (clockGate clk (fmap isJust iM)) rst initial (fmap fromJust iM)))
 {-# INLINE regMaybe #-}
 infixr 3 `regMaybe`
 
@@ -510,7 +439,7 @@ infixr 3 `regMaybe`
 -- >>> sampleN 8 count
 -- [0,0,1,1,2,2,3,3]
 regEn
-  :: (HasClockReset domain gated synchronous, HasCallStack)
+  :: (HiddenClockReset domain, HasCallStack)
   => a
   -- ^ Reset value
   --
@@ -520,7 +449,7 @@ regEn
   -> Signal domain a
   -> Signal domain a
 regEn = \initial en i -> withFrozenCallStack
-  (register# (clockGate ?clk en) ?rst initial i)
+  (hideClockReset (\clk rst -> register# (clockGate clk en) rst initial i))
 {-# INLINE regEn #-}
 
 -- * Signal -> List conversion
@@ -534,15 +463,18 @@ regEn = \initial en i -> withFrozenCallStack
 --
 -- __NB__: This function is not synthesisable
 sample
-  :: NFData a
-  => ((HasClockReset domain 'Source 'Asynchronous) => Signal domain a)
-  -- ^ 'Signal' we want to sample, whose source potentially needs an implicitly
-  -- routed clock (and reset)
+  :: forall domain a
+   . NFData a
+  => (HiddenClockReset domain => Signal domain a)
+  -- ^ 'Signal' we want to sample, whose source potentially has a hidden clock
+  -- (and reset)
   -> [a]
 sample s =
-  let ?clk = unsafeCoerce (clockGen @System)
-      ?rst = unsafeCoerce (Async @System (True :- pure False))
-  in  S.sample s
+  let clk = unsafeCoerce @(Clock System 'Source)
+                         @(Clock domain 'Source)
+                         (Clock @System SSymbol SNat)
+      rst = Async (True :- pure False)
+  in  S.sample (exposeClockReset s clk rst)
 
 -- | Get a list of /n/ samples from a 'Signal'
 --
@@ -553,17 +485,20 @@ sample s =
 --
 -- __NB__: This function is not synthesisable
 sampleN
-  :: NFData a
+  :: forall domain a
+   . NFData a
   => Int
   -- ^ The number of samples we want to see
-  -> ((HasClockReset domain 'Source 'Asynchronous) => Signal domain a)
-  -- ^ 'Signal' we want to sample, whose source potentially needs an implicitly
-  -- routed clock (and reset)
+  -> (HiddenClockReset domain => Signal domain a)
+  -- ^ 'Signal' we want to sample, whose source potentially has a hidden clock
+  -- (and reset)
   -> [a]
 sampleN n s =
-  let ?clk = unsafeCoerce (Clock @System SSymbol SNat)
-      ?rst = unsafeCoerce (Async @System (True :- pure False))
-  in  S.sampleN n s
+  let clk = unsafeCoerce @(Clock System 'Source)
+                         @(Clock domain 'Source)
+                         (Clock @System SSymbol SNat)
+      rst = Async (True :- pure False)
+  in  S.sampleN n (exposeClockReset s clk rst)
 
 -- | /Lazily/ get an infinite list of samples from a 'Clash.Signal.Signal'
 --
@@ -574,14 +509,17 @@ sampleN n s =
 --
 -- __NB__: This function is not synthesisable
 sample_lazy
-  :: ((HasClockReset domain 'Source 'Asynchronous) => Signal domain a)
-  -- ^ 'Signal' we want to sample, whose source potentially needs an implicitly
-  -- routed clock (and reset)
+  :: forall domain a
+   . (HiddenClockReset domain => Signal domain a)
+  -- ^ 'Signal' we want to sample, whose source potentially has a hidden clock
+  -- (and reset)
   -> [a]
 sample_lazy s =
-  let ?clk = unsafeCoerce (Clock @System SSymbol SNat)
-      ?rst = unsafeCoerce (Async @System (True :- pure False))
-  in  S.sample_lazy s
+  let clk = unsafeCoerce @(Clock System 'Source)
+                         @(Clock domain 'Source)
+                         (Clock @System SSymbol SNat)
+      rst = Async (True :- pure False)
+  in  S.sample_lazy (exposeClockReset s clk rst)
 
 
 -- | Lazily get a list of /n/ samples from a 'Signal'
@@ -593,15 +531,18 @@ sample_lazy s =
 --
 -- __NB__: This function is not synthesisable
 sampleN_lazy
-  :: Int
-  -> ((HasClockReset domain 'Source 'Asynchronous) => Signal domain a)
-  -- ^ 'Signal' we want to sample, whose source potentially needs an implicitly
-  -- routed clock (and reset)
+  :: forall domain a
+   . Int
+  -> (HiddenClockReset domain => Signal domain a)
+  -- ^ 'Signal' we want to sample, whose source potentially has a hidden clock
+  -- (and reset)
   -> [a]
 sampleN_lazy n s =
-  let ?clk = unsafeCoerce (Clock @System SSymbol SNat)
-      ?rst = unsafeCoerce (Async @System (True :- pure False))
-  in  S.sampleN_lazy n s
+  let clk = unsafeCoerce @(Clock System 'Source)
+                         @(Clock domain 'Source)
+                         (Clock @System SSymbol SNat)
+      rst = Async (True :- pure False)
+  in  S.sampleN_lazy n (exposeClockReset s clk rst)
 
 -- * Simulation functions
 
@@ -614,17 +555,20 @@ sampleN_lazy n s =
 --
 -- __NB__: This function is not synthesisable
 simulate
-  :: (NFData a, NFData b)
-  => ((HasClockReset domain 'Source 'Asynchronous) =>
+  :: forall domain a b
+   . (NFData a, NFData b)
+  => (HiddenClockReset domain =>
       Signal domain a -> Signal domain b)
-  -- ^ Function we want to simulate, whose components potentially needs an
-  -- implicitly routed clock (and reset)
+  -- ^ 'Signal' we want to sample, whose source potentially has a hidden clock
+  -- (and reset)
   -> [a]
   -> [b]
 simulate f =
-  let ?clk = unsafeCoerce (Clock @System SSymbol SNat)
-      ?rst = unsafeCoerce (Async @System (True :- pure False))
-  in  S.simulate f
+  let clk = unsafeCoerce @(Clock System 'Source)
+                         @(Clock domain 'Source)
+                         (Clock @System SSymbol SNat)
+      rst = Async (True :- pure False)
+  in  S.simulate (exposeClockReset f clk rst)
 
 -- | /Lazily/ simulate a (@'Signal' a -> 'Signal' b@) function given a list of
 -- samples of type /a/
@@ -635,16 +579,19 @@ simulate f =
 --
 -- __NB__: This function is not synthesisable
 simulate_lazy
-  :: ((HasClockReset domain 'Source 'Asynchronous) =>
+  :: forall domain a b
+   . (HiddenClockReset domain =>
       Signal domain a -> Signal domain b)
-  -- ^ Function we want to simulate, whose components potentially needs an
-  -- implicitly routed clock (and reset)
+  -- ^ Function we want to simulate, whose components potentially have a hidden
+  -- clock (and reset)
   -> [a]
   -> [b]
 simulate_lazy f =
-  let ?clk = unsafeCoerce (Clock @System SSymbol SNat)
-      ?rst = unsafeCoerce (Async @System (True :- pure False))
-  in  S.simulate_lazy f
+  let clk = unsafeCoerce @(Clock System 'Source)
+                         @(Clock domain 'Source)
+                         (Clock @System SSymbol SNat)
+      rst = Async (True :- pure False)
+  in  S.simulate_lazy (exposeClockReset f clk rst)
 
 -- | Simulate a (@'Unbundled' a -> 'Unbundled' b@) function given a list of
 -- samples of type @a@
@@ -655,17 +602,20 @@ simulate_lazy f =
 --
 -- __NB__: This function is not synthesisable
 simulateB
-  :: (Bundle a, Bundle b, NFData a, NFData b)
-  => ((HasClockReset domain 'Source 'Asynchronous) =>
+  :: forall domain a b
+   . (Bundle a, Bundle b, NFData a, NFData b)
+  => (HiddenClockReset domain =>
       Unbundled domain a -> Unbundled domain b)
-  -- ^ Function we want to simulate, whose components potentially needs an
-  -- implicitly routed clock (and reset)
+  -- ^ Function we want to simulate, whose components potentially have a hidden
+  -- clock (and reset)
   -> [a]
   -> [b]
 simulateB f =
-  let ?clk = unsafeCoerce (Clock @System SSymbol SNat)
-      ?rst = unsafeCoerce (Async @System (True :- pure False))
-  in  S.simulateB f
+  let clk = unsafeCoerce @(Clock System 'Source)
+                         @(Clock domain 'Source)
+                         (Clock @System SSymbol SNat)
+      rst = Async (True :- pure False)
+  in  S.simulateB (exposeClockReset f clk rst)
 
 -- | /Lazily/ simulate a (@'Unbundled' a -> 'Unbundled' b@) function given a
 -- list of samples of type @a@
@@ -676,17 +626,20 @@ simulateB f =
 --
 -- __NB__: This function is not synthesisable
 simulateB_lazy
-  :: (Bundle a, Bundle b)
-  => ((HasClockReset domain 'Source 'Asynchronous) =>
+  :: forall domain a b
+   . (Bundle a, Bundle b)
+  => (HiddenClockReset domain =>
       Unbundled domain a -> Unbundled domain b)
-  -- ^ Function we want to simulate, whose components potentially needs an
-  -- implicitly routed clock (and reset)
+  -- ^ Function we want to simulate, whose components potentially have a hidden
+  -- clock (and reset)
   -> [a]
   -> [b]
 simulateB_lazy f =
-  let ?clk = unsafeCoerce (Clock @System SSymbol SNat)
-      ?rst = unsafeCoerce (Async @System (True :- pure False))
-  in  S.simulateB_lazy f
+  let clk = unsafeCoerce @(Clock System 'Source)
+                         @(Clock domain 'Source)
+                         (Clock @System SSymbol SNat)
+      rst = Async (True :- pure False)
+  in  S.simulateB_lazy (exposeClockReset f clk rst)
 
 -- * QuickCheck combinators
 
@@ -694,8 +647,8 @@ simulateB_lazy f =
 testFor
   :: Int
   -- ^ The number of cycles we want to test for
-  -> ((HasClockReset domain 'Source 'Asynchronous) => Signal domain Bool)
-  -- ^ 'Signal' we want to evaluate, whose source potentially needs an
-  -- implicitly routed clock (and reset)
+  -> (HiddenClockReset domain => Signal domain Bool)
+  -- ^ 'Signal' we want to evaluate, whose source potentially has a hidden clock
+  -- (and reset)
   -> Property
 testFor n s = property (and (Clash.Signal.sampleN n s))

--- a/src/Clash/Signal/Delayed.hs
+++ b/src/Clash/Signal/Delayed.hs
@@ -5,11 +5,12 @@ License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 -}
 
-{-# LANGUAGE CPP                        #-}
-{-# LANGUAGE DataKinds                  #-}
-{-# LANGUAGE KindSignatures             #-}
-{-# LANGUAGE ScopedTypeVariables        #-}
-{-# LANGUAGE TypeOperators              #-}
+{-# LANGUAGE CPP                 #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE KindSignatures      #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeOperators       #-}
 
 {-# LANGUAGE Trustworthy #-}
 
@@ -41,13 +42,13 @@ import           Clash.Explicit.Signal.Delayed
    unsafeFromSignal, antiDelay)
 import            Clash.Sized.Vector           (Vec)
 import            Clash.Signal
-  (HasClockReset, hasClock, hasReset)
+  (HiddenClockReset, hideClockReset)
 
 {- $setup
->>> :set -XDataKinds -XTypeOperators -XTypeApplications
+>>> :set -XDataKinds -XTypeOperators -XTypeApplications -XFlexibleContexts
 >>> import Clash.Prelude
 >>> let delay3 = delayed (0 :> 0 :> 0 :> Nil)
->>> let delay2 = delayedI :: HasClockReset domain gated synchronous => DSignal domain n Int -> DSignal domain (n + 2) Int
+>>> let delay2 = delayedI :: HiddenClockReset domain => DSignal domain n Int -> DSignal domain (n + 2) Int
 -}
 
 -- | Delay a 'DSignal' for @d@ periods.
@@ -60,11 +61,11 @@ import            Clash.Signal
 -- >>> sampleN 6 (toSignal (delay3 (dfromList [1..])))
 -- [0,0,0,1,2,3]
 delayed
-  :: (KnownNat d, HasClockReset domain gated synchronous)
+  :: (KnownNat d, HiddenClockReset domain)
   => Vec d a
   -> DSignal domain n a
   -> DSignal domain (n + d) a
-delayed = E.delayed hasClock hasReset
+delayed = hideClockReset E.delayed
 
 -- | Delay a 'DSignal' for @m@ periods, where @m@ is derived from the context.
 --
@@ -76,7 +77,7 @@ delayed = E.delayed hasClock hasReset
 -- >>> sampleN 6 (toSignal (delay2 (dfromList [1..])))
 -- [0,0,1,2,3,4]
 delayedI
-  :: (Default a, KnownNat d, HasClockReset domain gated synchronous)
+  :: (Default a, KnownNat d, HiddenClockReset domain)
   => DSignal domain n a
   -> DSignal domain (n + d) a
-delayedI = E.delayedI hasClock hasReset
+delayedI = hideClockReset E.delayedI

--- a/src/Clash/Tutorial.hs
+++ b/src/Clash/Tutorial.hs
@@ -909,13 +909,12 @@ topEntity
   -> Reset Dom50 Asynchronous
   -> Signal Dom50 Bit
   -> Signal Dom50 (BitVector 8)
-topEntity clk rst key1 =
-    let  (pllOut,pllStable) = 'Clash.Intel.ClockGen.altpll' (SSymbol @ "altpll50") clk rst
-         rstSync            = 'Clash.Signal.resetSynchronizer' pllOut ('Clash.Signal.unsafeToAsyncReset' pllStable)
-    in   'Clash.Signal.exposeClockReset' leds pllOut rstSync
+topEntity clk rst = 'Clash.Signal.exposeClockReset' (\\key1 ->
+    let key1R = 'Clash.Prelude.isRising' 1 key1
+    in  'Clash.Prelude.mealy' blinkerT (1,False,0) key1R) pllOut rstSync
   where
-    key1R  = 'Clash.Prelude.isRising' 1 key1
-    leds   = 'Clash.Prelude.mealy' blinkerT (1,False,0) key1R
+    (pllOut,pllStable) = 'Clash.Intel.ClockGen.altpll' @@Dom50 (SSymbol @@"altpll50") clk rst
+    rstSync            = 'Clash.Signal.resetSynchronizer' pllOut ('Clash.Signal.unsafeToAsyncReset' pllStable)
 
 blinkerT (leds,mode,cntr) key1R = ((leds',mode',cntr'),leds)
   where

--- a/src/Clash/Tutorial.hs
+++ b/src/Clash/Tutorial.hs
@@ -72,6 +72,7 @@ where
 
 import Clash.Prelude
 import Clash.Explicit.Prelude (freqCalc)
+import Clash.Explicit.Testbench
 import Control.Monad.ST
 import Data.Array
 import Data.Char
@@ -125,9 +126,9 @@ topEntity = exposeClockReset mac
 let testBench :: Signal System Bool
     testBench = done
       where
-        testInput      = stimuliGenerator $(listToVecTH [(1,1) :: (Signed 9,Signed 9),(2,2),(3,3),(4,4)])
-        expectedOutput = outputVerifier $(listToVecTH [0 :: Signed 9,1,5,14])
-        done           = exposeClockReset (expectedOutput (topEntity clk rst testInput)) clk rst
+        testInput      = stimuliGenerator clk rst $(listToVecTH [(1,1) :: (Signed 9,Signed 9),(2,2),(3,3),(4,4)])
+        expectedOutput = outputVerifier clk rst $(listToVecTH [0 :: Signed 9,1,5,14])
+        done           = expectedOutput (topEntity clk rst testInput)
         clk            = tbSystemClockGen (not <$> done)
         rst            = systemResetGen
 :}
@@ -560,6 +561,8 @@ order for the CλaSH compiler to do this you need to do one of the following:
 For example, you can test the earlier defined /topEntity/ by:
 
 @
+import Clash.Explicit.Testbench
+
 topEntity
   :: 'Clock' System 'Source'
   -> 'Reset' System 'Asynchronous'
@@ -571,9 +574,9 @@ topEntity = 'exposeClockReset' mac
 testBench :: 'Signal' System Bool
 testBench = done
   where
-    testInput    = 'stimuliGenerator' $('listToVecTH' [(1,1) :: ('Signed' 9,'Signed' 9),(2,2),(3,3),(4,4)])
-    expectOutput = 'outputVerifier' $('listToVecTH' [0 :: 'Signed' 9,1,5,14])
-    done         = 'exposeClockReset' (expectOutput (topEntity clk rst testInput)) clk rst
+    testInput    = 'stimuliGenerator' clk rst $('listToVecTH' [(1,1) :: ('Signed' 9,'Signed' 9),(2,2),(3,3),(4,4)])
+    expectOutput = 'outputVerifier' clk rst $('listToVecTH' [0 :: 'Signed' 9,1,5,14])
+    done         = expectOutput (topEntity clk rst testInput)
     clk          = 'tbSystemClockGen' (not '<$>' done)
     rst          = 'systemResetGen'
 @

--- a/src/Clash/Xilinx/ClockGen.hs
+++ b/src/Clash/Xilinx/ClockGen.hs
@@ -6,8 +6,9 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 PLL and other clock-related components for Xilinx FPGAs
 -}
 
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE GADTs     #-}
+{-# LANGUAGE DataKinds      #-}
+{-# LANGUAGE ExplicitForAll #-}
+{-# LANGUAGE GADTs          #-}
 module Clash.Xilinx.ClockGen where
 
 import Clash.Promoted.Symbol
@@ -24,8 +25,18 @@ import Unsafe.Coerce
 -- * 1 output clock
 -- * a reset port
 -- * a locked port
+--
+-- You must use type applications to specify the output clock domain, e.g.:
+--
+-- @
+-- type Dom100MHz = Dom \"A\" 10000
+--
+-- -- outputs a clock running at 100 MHz
+-- clockWizard @@Dom100MHz (SSymbol @@"clkWizard50to100") clk50 rst
+-- @
 clockWizard
-  :: SSymbol name
+  :: forall pllOut pllIn name
+   . SSymbol name
   -- ^ Name of the component, must correspond to the name entered in the
   -- \"Clock Wizard\" dialog.
   --
@@ -52,8 +63,18 @@ clockWizard _ clk (Async rst) =
 -- * 1 output clock
 -- * a reset port
 -- * a locked port
+--
+-- You must use type applications to specify the output clock domain, e.g.:
+--
+-- @
+-- type Dom100MHz = Dom \"A\" 10000
+--
+-- -- outputs a clock running at 100 MHz
+-- clockWizardDifferential @@Dom100MHz (SSymbol @@"clkWizardD50to100") clk50N clk50P rst
+-- @
 clockWizardDifferential
-  :: SSymbol name
+  :: forall pllOut pllIn name
+   . SSymbol name
   -- ^ Name of the component, must correspond to the name entered in the
   -- \"Clock Wizard\" dialog.
   --


### PR DESCRIPTION
~~No longer do we have to be amazed by `ImplicitParams` dynamic scoping behaviour.~~ The `reflection`-based API suffers from the same scoping annoyances as the `ImplicitParams` one [1]. Additionally, we can now have multiple hidden clocks, e.g.:

```haskell
f :: (HiddenClock domA, HiddenClock domB) 
  => Signal domA Bool 
  -> Signal domB Int 
  -> Signal domB Int
```

which is something that didn't work when we used implicit parameters.

However, you do lose the convenience of `ImplicitParams` binding construct.

# [1] The scoping issue:

## ImplicitParams
With the `ImplicitParams` API, this works

```haskell
f :: Signal dom a -> Clock dom gated -> Signal dom b
f x = withClockReset ... $
    let rr = register undefined
    in ... g ...
```
but the following gives an "Unbound implicit param" error:

```haskell
f :: Signal dom a -> Clock dom gated -> Signal dom b
f x = withClockReset ... g
  where rr = register undefined
        g = ...
```

## Reflection
With the `reflection` API, this works

```haskell
f :: Signal dom a -> Clock dom gated -> Signal dom b
f x = exposeClockReset $
    let rr = register undefined
    in ... g ...
```

but the following gives an "No instance for Given (SomeClock domain)" error:

```haskell
f :: Signal dom a ->  Clock dom gated -> Signal dom b
f x = exposeClockReset g
  where rr = register undefined
        g = ...
```