### PR TITLE
Work around fromJust

### DIFF
--- a/src/Clash/Explicit/BlockRam.hs
+++ b/src/Clash/Explicit/BlockRam.hs
@@ -392,7 +392,7 @@ module Clash.Explicit.BlockRam
   )
 where
 
-import Data.Maybe             (fromJust, isJust)
+import Data.Maybe             (isJust)
 import qualified Data.Vector  as V
 import GHC.Stack              (HasCallStack, withFrozenCallStack)
 import GHC.TypeLits           (KnownNat, type (^))
@@ -699,6 +699,9 @@ blockRam
 blockRam = \clk content rd wrM ->
   let en       = isJust <$> wrM
       (wr,din) = unbundle (fromJust <$> wrM)
+      -- Data.Maybe.fromJust may not have an unfolding; see #274
+      fromJust Nothing = error "Clash.Explicit.BlockRam.blockRam: impossible"
+      fromJust (Just x) = x
   in  withFrozenCallStack
       (blockRam# clk content (fromEnum <$> rd) en (fromEnum <$> wr) din)
 {-# INLINE blockRam #-}

--- a/src/Clash/Explicit/BlockRam/File.hs
+++ b/src/Clash/Explicit/BlockRam/File.hs
@@ -98,7 +98,7 @@ module Clash.Explicit.BlockRam.File
 where
 
 import Data.Char             (digitToInt)
-import Data.Maybe            (fromJust, isJust, listToMaybe)
+import Data.Maybe            (isJust, listToMaybe)
 import qualified Data.Vector as V
 import GHC.Stack             (HasCallStack, withFrozenCallStack)
 import GHC.TypeLits          (KnownNat)
@@ -199,6 +199,9 @@ blockRamFile
 blockRamFile = \clk sz file rd wrM ->
   let en       = isJust <$> wrM
       (wr,din) = unbundle (fromJust <$> wrM)
+      -- Data.Maybe.fromJust may not have an unfolding; see #274
+      fromJust Nothing = error "Clash.Explicit.BlockRam.File.blockRamFile: impossible"
+      fromJust (Just x) = x
   in  withFrozenCallStack
       (blockRamFile# clk sz file (fromEnum <$> rd) en (fromEnum <$> wr) din)
 {-# INLINE blockRamFile #-}

--- a/src/Clash/Explicit/RAM.hs
+++ b/src/Clash/Explicit/RAM.hs
@@ -34,7 +34,7 @@ module Clash.Explicit.RAM
   )
 where
 
-import Data.Maybe            (fromJust, isJust)
+import Data.Maybe            (isJust)
 import GHC.Stack             (HasCallStack, withFrozenCallStack)
 import GHC.TypeLits          (KnownNat)
 import qualified Data.Vector as V
@@ -96,6 +96,9 @@ asyncRam
 asyncRam = \wclk rclk sz rd wrM ->
   let en       = isJust <$> wrM
       (wr,din) = unbundle (fromJust <$> wrM)
+      -- Data.Maybe.fromJust may not have an unfolding; see #274
+      fromJust Nothing = error "Clash.Explicit.RAM.asyncRam: impossible"
+      fromJust (Just x) = x
   in  withFrozenCallStack
       (asyncRam# wclk rclk sz (fromEnum <$> rd) en (fromEnum <$> wr) din)
 {-# INLINE asyncRam #-}

--- a/src/Clash/Explicit/Signal.hs
+++ b/src/Clash/Explicit/Signal.hs
@@ -195,7 +195,7 @@ module Clash.Explicit.Signal
 where
 
 import Control.DeepSeq       (NFData)
-import Data.Maybe            (isJust, fromJust)
+import Data.Maybe            (isJust)
 import GHC.Stack             (HasCallStack, withFrozenCallStack)
 
 import Clash.Signal.Internal
@@ -517,6 +517,10 @@ regMaybe
   -> Signal domain a
 regMaybe = \clk rst initial iM -> withFrozenCallStack
   (register# (clockGate clk (fmap isJust iM)) rst initial (fmap fromJust iM))
+  where
+    -- Data.Maybe.fromJust may not have an unfolding; see #274
+    fromJust Nothing = error "Clash.Signal.Explicit.regMaybe: Nothing"
+    fromJust (Just x) = x
 {-# INLINE regMaybe #-}
 
 -- | Version of 'register' that only updates its content when its fourth

--- a/src/Clash/Signal.hs
+++ b/src/Clash/Signal.hs
@@ -123,7 +123,7 @@ import           Control.DeepSeq       (NFData)
 import           GHC.Stack             (HasCallStack, withFrozenCallStack)
 import           GHC.TypeLits          (KnownNat, KnownSymbol)
 import           Data.Bits             (Bits) -- Haddock only
-import           Data.Maybe            (isJust, fromJust)
+import           Data.Maybe            (isJust)
 import           Test.QuickCheck       (Property, property)
 import           Unsafe.Coerce         (unsafeCoerce)
 
@@ -492,6 +492,10 @@ regMaybe
   -> Signal domain a
 regMaybe = \initial iM -> withFrozenCallStack
   (register# (clockGate ?clk (fmap isJust iM)) ?rst initial (fmap fromJust iM))
+  where
+    -- Data.Maybe.fromJust may not have an unfolding; see #274
+    fromJust Nothing = error "Clash.Signal.regMaybe: Nothing"
+    fromJust (Just x) = x
 {-# INLINE regMaybe #-}
 infixr 3 `regMaybe`
 

--- a/src/Clash/Sized/Fixed.hs
+++ b/src/Clash/Sized/Fixed.hs
@@ -76,7 +76,6 @@ import Data.Data                  (Data)
 import Data.Default               (Default (..))
 import Text.Read                  (Read(..))
 import Data.List                  (find)
-import Data.Maybe                 (fromJust)
 import Data.Proxy                 (Proxy (..))
 import Data.Ratio                 ((%), denominator, numerator)
 import Data.Typeable              (Typeable, TypeRep, typeRep)
@@ -263,6 +262,9 @@ instance ( size ~ (int + frac), KnownNat frac, Integral (rep size)
       nom       = if fRepI < 0 then fRepI_abs .&. ((2 ^ nF) - 1)
                                else fRepI .&. ((2 ^ nF) - 1)
       denom     = 2 ^ nF
+
+      fromJust Nothing = error "show(Clash.Sized.Fixed.Fixed): Nothing"
+      fromJust (Just x) = x
 
 instance ( size ~ (int + frac), KnownNat frac, Integral (rep size)
          ) => ShowX (Fixed rep int frac) where


### PR DESCRIPTION
As noted in https://github.com/clash-lang/clash-compiler/pull/274 `Data.Maybe.fromJust` has no unfolding in GHC 8.2. Here I remove instances of `fromJust` from `clash-prelude`. This works around the issue and perhaps offers slightly better error messages at the expense of some verbosity. It's not clear to me that this is the right trade-off but it's been a useful temporary hack for me.