### PR TITLE
 Make `Bit` a newtype instead of a type alias

### DIFF
--- a/src/Clash/Examples.hs
+++ b/src/Clash/Examples.hs
@@ -106,7 +106,7 @@ upDownCounter upDown = s
     s = register 0 (mux upDown (s + 1) (s - 1))
 
 lfsrF' :: BitVector 16 -> BitVector 16
-lfsrF' s = feedback ++# slice d15 d1 s
+lfsrF' s = pack feedback ++# slice d15 d1 s
   where
     feedback = s!5 `xor` s!3 `xor` s!2 `xor` s!0
 
@@ -133,7 +133,7 @@ lfsrG seed = last (unbundle r)
 grayCounter :: HasClockReset domain gated synchronous
             => Signal domain Bool -> Signal domain (BitVector 8)
 grayCounter en = gray <$> upCounter en
-  where gray xs = msb xs ++# xor (slice d7 d1 xs) (slice d6 d0 xs)
+  where gray xs = pack (msb xs) ++# xor (slice d7 d1 xs) (slice d6 d0 xs)
 
 oneHotCounter :: HasClockReset domain gated synchronous
               => Signal domain Bool -> Signal domain (BitVector 8)
@@ -410,7 +410,7 @@ External/Fibonacci LFSR, for @n=16@ and using the primitive polynominal @1 + x^1
 
 @
 lfsrF' :: BitVector 16 -> BitVector 16
-lfsrF' s = feedback '++#' 'slice' d15 d1 s
+lfsrF' s = 'pack' feedback '++#' 'slice' d15 d1 s
   where
     feedback = s'!'5 ``xor`` s'!'3 ``xor`` s'!'2 ``xor`` s'!'0
 
@@ -449,7 +449,7 @@ Using the previously defined @upCounter@:
 @
 grayCounter :: Signal Bool -> Signal (BitVector 8)
 grayCounter en = gray '<$>' upCounter en
-  where gray xs = 'msb' xs '++#' 'xor' ('slice' d7 d1 xs) ('slice' d6 d0 xs)
+  where gray xs = 'pack' ('msb' xs) '++#' 'xor' ('slice' d7 d1 xs) ('slice' d6 d0 xs)
 @
 
 = One-hot counter

--- a/src/Clash/Signal/Bundle.hs
+++ b/src/Clash/Signal/Bundle.hs
@@ -30,7 +30,7 @@ import Prelude               hiding (head, map, tail)
 
 import Clash.NamedTypes      ((:::))
 import Clash.Signal.Internal (Domain, Signal (..))
-import Clash.Sized.BitVector (BitVector)
+import Clash.Sized.BitVector (Bit, BitVector)
 import Clash.Sized.Fixed     (Fixed)
 import Clash.Sized.Index     (Index)
 import Clash.Sized.Signed    (Signed)
@@ -114,6 +114,7 @@ instance Bundle Double
 instance Bundle (Maybe a)
 instance Bundle (Either a b)
 
+instance Bundle Bit
 instance Bundle (BitVector n)
 instance Bundle (Index n)
 instance Bundle (Fixed rep int frac)

--- a/src/Clash/Sized/BitVector.hs
+++ b/src/Clash/Sized/BitVector.hs
@@ -11,17 +11,19 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 {-# OPTIONS_HADDOCK show-extensions #-}
 
 module Clash.Sized.BitVector
-  ( -- * Datatypes
-    BitVector
-  , Bit
-    -- * Accessors
-    -- ** Length information
-  , size#
-  , maxIndex#
-    -- * Construction
-    -- ** Initialisation
+  ( -- * Bit
+    Bit
+    -- ** Construction
+    -- *** Initialisation
   , high
   , low
+    -- * BitVector
+  , BitVector
+    -- ** Accessors
+    -- *** Length information
+  , size#
+  , maxIndex#
+    -- ** Construction
   , bLit
     -- ** Concatenation
   , (++#)

--- a/src/Clash/Sized/Fixed.hs
+++ b/src/Clash/Sized/Fixed.hs
@@ -816,8 +816,8 @@ instance NumFixedC rep int frac => SaturatingNum (Fixed rep int frac) where
         sh      = fromInteger (natVal (Proxy @frac))
         (rL,rR) = split res :: (BitVector int, BitVector (int + frac + frac))
     in  case isSigned a of
-          True  -> let overflow = complement (reduceOr (msb rR ++# pack rL)) .|.
-                                             reduceAnd (msb rR ++# pack rL)
+          True  -> let overflow = complement (reduceOr (pack (msb rR) ++# pack rL)) .|.
+                                             reduceAnd (pack (msb rR) ++# pack rL)
                    in  case overflow of
                          1 -> unpack (resize (shiftR rR sh))
                          _ -> case msb rL of
@@ -832,8 +832,8 @@ instance NumFixedC rep int frac => SaturatingNum (Fixed rep int frac) where
         sh      = fromInteger (natVal (Proxy @frac))
         (rL,rR) = split res :: (BitVector int, BitVector (int + frac + frac))
     in  case isSigned a of
-          True  -> let overflow = complement (reduceOr (msb rR ++# pack rL)) .|.
-                                             reduceAnd (msb rR ++# pack rL)
+          True  -> let overflow = complement (reduceOr (pack (msb rR) ++# pack rL)) .|.
+                                             reduceAnd (pack (msb rR) ++# pack rL)
                    in  case overflow of
                          1 -> unpack (resize (shiftR rR sh))
                          _ -> 0
@@ -846,8 +846,8 @@ instance NumFixedC rep int frac => SaturatingNum (Fixed rep int frac) where
         sh      = fromInteger (natVal (Proxy @frac))
         (rL,rR) = split res :: (BitVector int, BitVector (int + frac + frac))
     in  case isSigned a of
-          True  -> let overflow = complement (reduceOr (msb rR ++# pack rL)) .|.
-                                             reduceAnd (msb rR ++# pack rL)
+          True  -> let overflow = complement (reduceOr (pack (msb rR) ++# pack rL)) .|.
+                                             reduceAnd (pack (msb rR) ++# pack rL)
                    in  case overflow of
                          1 -> unpack (resize (shiftR rR sh))
                          _ -> case msb rL of

--- a/src/Clash/Sized/Internal/BitVector.hs
+++ b/src/Clash/Sized/Internal/BitVector.hs
@@ -504,35 +504,17 @@ setSlice# (BV i) m n (BV j) = BV ((i .&. mask) .|. j')
     j'   = shiftL j (fromInteger n')
     mask = complement ((2 ^ (m' + 1) - 1) `xor` (2 ^ n' - 1))
 
-split#
-  :: KnownNat n
-  => BitVector (m + n)
-  -> (BitVector m, BitVector n)
-split# bv = (splitL# bv, splitR# bv)
-{-# INLINE split# #-}
-
-splitL#
-  :: forall n m
-   . KnownNat n
-  => BitVector (m + n)
-  -> BitVector m
-splitL# (BV i) = BV l
- where
-  n     = fromInteger (natVal (Proxy @n))
-  l     = i `shiftR` n
-{-# NOINLINE splitL# #-}
-
-splitR#
-  :: forall n m
-   . KnownNat n
-  => BitVector (m + n)
-  -> BitVector n
-splitR# (BV i) = BV r
- where
-  n     = fromInteger (natVal (Proxy @n))
-  mask  = 1 `shiftL` n
-  r     = i `mod` mask
-{-# NOINLINE splitR# #-}
+{-# NOINLINE split# #-}
+split# :: forall n m . KnownNat n
+       => BitVector (m + n) -> (BitVector m, BitVector n)
+split# (BV i) = (BV l, BV r)
+  where
+    n     = fromInteger (natVal (Proxy @n))
+    mask  = 1 `shiftL` n
+    -- The code below is faster than:
+    -- > (l,r) = i `divMod` mask
+    r    = i `mod` mask
+    l    = i `shiftR` n
 
 and#, or#, xor# :: BitVector n -> BitVector n -> BitVector n
 {-# NOINLINE and# #-}

--- a/src/Clash/Sized/Internal/BitVector.hs-boot
+++ b/src/Clash/Sized/Internal/BitVector.hs-boot
@@ -13,4 +13,4 @@ import GHC.TypeLits (Nat)
 
 type role BitVector phantom
 data BitVector :: Nat -> *
-type Bit = BitVector 1
+data Bit

--- a/src/Clash/Sized/Internal/Signed.hs
+++ b/src/Clash/Sized/Internal/Signed.hs
@@ -357,7 +357,7 @@ instance KnownNat n => Bits (Signed n) where
   bit i             = replaceBit i high 0
   setBit v i        = replaceBit i high v
   clearBit v i      = replaceBit i low  v
-  complementBit v i = replaceBit i (BV.complement# (v ! i)) v
+  complementBit v i = replaceBit i (BV.complement## (v ! i)) v
   testBit v i       = v ! i == 1
   bitSizeMaybe v    = Just (size# v)
   bitSize           = size#
@@ -482,7 +482,7 @@ instance KnownNat n => SaturatingNum (Signed n) where
         (_,r') = split r
     in  case msb r `xor` msb r' of
           0 -> unpack# r'
-          _ -> case msb a ++# msb b of
+          _ -> case BV.pack# (msb a) ++# BV.pack# (msb b) of
             2 -> minBound#
             _ -> maxBound#
   satMin SatZero a b =
@@ -496,7 +496,7 @@ instance KnownNat n => SaturatingNum (Signed n) where
         (_,r') = split r
     in  case msb r `xor` msb r' of
           0 -> unpack# r'
-          _ -> case msb a ++# msb b of
+          _ -> case BV.pack# (msb a) ++# BV.pack# (msb b) of
             2 -> minBoundSym#
             _ -> maxBound#
 
@@ -504,8 +504,8 @@ instance KnownNat n => SaturatingNum (Signed n) where
   satMult SatBound a b =
     let r        = times# a b
         (rL,rR)  = split r
-        overflow = complement (reduceOr (msb rR ++# pack rL)) .|.
-                              reduceAnd (msb rR ++# pack rL)
+        overflow = complement (reduceOr (BV.pack# (msb rR) ++# pack rL)) .|.
+                              reduceAnd (BV.pack# (msb rR) ++# pack rL)
     in  case overflow of
           1 -> unpack# rR
           _ -> case msb rL of
@@ -514,16 +514,16 @@ instance KnownNat n => SaturatingNum (Signed n) where
   satMult SatZero a b =
     let r        = times# a b
         (rL,rR)  = split r
-        overflow = complement (reduceOr (msb rR ++# pack rL)) .|.
-                              reduceAnd (msb rR ++# pack rL)
+        overflow = complement (reduceOr (BV.pack# (msb rR) ++# pack rL)) .|.
+                              reduceAnd (BV.pack# (msb rR) ++# pack rL)
     in  case overflow of
           1 -> unpack# rR
           _ -> fromInteger# 0
   satMult SatSymmetric a b =
     let r        = times# a b
         (rL,rR)  = split r
-        overflow = complement (reduceOr (msb rR ++# pack rL)) .|.
-                              reduceAnd (msb rR ++# pack rL)
+        overflow = complement (reduceOr (BV.pack# (msb rR) ++# pack rL)) .|.
+                              reduceAnd (BV.pack# (msb rR) ++# pack rL)
     in  case overflow of
           1 -> unpack# rR
           _ -> case msb rL of

--- a/src/Clash/Sized/Internal/Unsigned.hs
+++ b/src/Clash/Sized/Internal/Unsigned.hs
@@ -243,7 +243,7 @@ instance KnownNat n => Num (Unsigned n) where
   (*)         = (*#)
   negate      = negate#
   abs         = id
-  signum bv   = resize# (unpack# (reduceOr bv))
+  signum bv   = resize# (unpack# (BV.pack# (reduceOr bv)))
   fromInteger = fromInteger#
 
 (+#),(-#),(*#) :: forall n . KnownNat n => Unsigned n -> Unsigned n -> Unsigned n
@@ -332,7 +332,7 @@ instance KnownNat n => Bits (Unsigned n) where
   bit i             = replaceBit i high 0
   setBit v i        = replaceBit i high v
   clearBit v i      = replaceBit i low  v
-  complementBit v i = replaceBit i (BV.complement# (v ! i)) v
+  complementBit v i = replaceBit i (BV.complement## (v ! i)) v
   testBit v i       = v ! i == high
   bitSizeMaybe v    = Just (size# v)
   bitSize           = size#


### PR DESCRIPTION
So that we can map `Bit` to `std_logic` in VHDL, and map `BitVector 1` to `std_logic_vector(0 downto 0)`