### PR TITLE
Export SSymbol from Clash.Prelude

### DIFF
--- a/src/Clash/Explicit/Prelude.hs
+++ b/src/Clash/Explicit/Prelude.hs
@@ -87,6 +87,7 @@ module Clash.Explicit.Prelude
   , module Clash.Promoted.Nat
   , module Clash.Promoted.Nat.Literals
   , module Clash.Promoted.Nat.TH
+    -- ** Type-level strings
   , module Clash.Promoted.Symbol
     -- ** Template Haskell
   , Lift (..)

--- a/src/Clash/Explicit/Prelude/Safe.hs
+++ b/src/Clash/Explicit/Prelude/Safe.hs
@@ -77,6 +77,7 @@ module Clash.Explicit.Prelude.Safe
   , module Clash.Promoted.Nat
   , module Clash.Promoted.Nat.Literals
   , module Clash.Promoted.Nat.TH
+    -- ** Type-level strings
   , module Clash.Promoted.Symbol
     -- ** Type classes
     -- *** Clash

--- a/src/Clash/Prelude.hs
+++ b/src/Clash/Prelude.hs
@@ -103,6 +103,8 @@ module Clash.Prelude
   , module Clash.Promoted.Nat
   , module Clash.Promoted.Nat.Literals
   , module Clash.Promoted.Nat.TH
+    -- ** Type-level strings
+  , module Clash.Promoted.Symbol
     -- ** Template Haskell
   , Lift (..)
     -- ** Type classes
@@ -154,6 +156,7 @@ import           Clash.Prelude.Safe
 import           Clash.Promoted.Nat
 import           Clash.Promoted.Nat.TH
 import           Clash.Promoted.Nat.Literals
+import           Clash.Promoted.Symbol
 import           Clash.Sized.BitVector
 import           Clash.Sized.Fixed
 import           Clash.Sized.Index

--- a/src/Clash/Prelude/Safe.hs
+++ b/src/Clash/Prelude/Safe.hs
@@ -91,6 +91,8 @@ module Clash.Prelude.Safe
   , module Clash.Promoted.Nat
   , module Clash.Promoted.Nat.Literals
   , module Clash.Promoted.Nat.TH
+    -- ** Type-level strings
+  , module Clash.Promoted.Symbol
     -- ** Type classes
     -- *** Clash
   , module Clash.Class.BitPack
@@ -139,6 +141,7 @@ import           Clash.Prelude.DataFlow
 import           Clash.Promoted.Nat
 import           Clash.Promoted.Nat.TH
 import           Clash.Promoted.Nat.Literals
+import           Clash.Promoted.Symbol
 import           Clash.Sized.BitVector
 import           Clash.Sized.Fixed
 import           Clash.Sized.Index

--- a/src/Clash/Signal/Internal.hs
+++ b/src/Clash/Signal/Internal.hs
@@ -109,7 +109,6 @@ import Clash.XException           (XException, errorX, seqX)
 >>> :set -XMagicHash
 >>> :set -XTypeApplications
 >>> import Clash.Promoted.Nat
->>> import Clash.Promoted.Symbol
 >>> import Clash.XException
 >>> type System = Dom "System" 10000
 >>> let systemClockGen = clockGen @System

--- a/src/Clash/Tutorial.hs
+++ b/src/Clash/Tutorial.hs
@@ -2356,7 +2356,6 @@ Blinker circuit in the current version:
 module Blinker where
 
 import Clash.Prelude
-import Clash.Promoted.Symbol
 import Clash.Intel.ClockGen
 
 type Dom50 = Dom \"System\" 20000


### PR DESCRIPTION
So we can use things like altpll without having to import yet another module.