### PR TITLE
Updated `Clash.Prelude` exports.

### DIFF
--- a/src/Clash/Prelude.hs
+++ b/src/Clash/Prelude.hs
@@ -74,6 +74,8 @@ module Clash.Prelude
   , windowD
   , isRising
   , isFalling
+  , riseEvery
+  , oscillate
     -- * Exported modules
     -- ** Synchronous signals
   , module Clash.Signal


### PR DESCRIPTION
Some exports of `Clash.Prelude.Safe` were, rather dubiously, not also being exported by `Clash.Prelude`.