### PR TITLE
Extra DSignal functionality

### DIFF
--- a/clash-prelude.cabal
+++ b/clash-prelude.cabal
@@ -136,6 +136,8 @@ Library
                       Clash.Signal
                       Clash.Signal.Bundle
                       Clash.Signal.Delayed
+                      Clash.Signal.Delayed.Bundle
+                      Clash.Signal.Delayed.Extra
                       Clash.Signal.Internal
 
                       Clash.Sized.BitVector

--- a/src/Clash/Signal/Delayed/Bundle.hs
+++ b/src/Clash/Signal/Delayed/Bundle.hs
@@ -1,0 +1,213 @@
+{-# LANGUAGE DataKinds              #-}
+{-# LANGUAGE DefaultSignatures      #-}
+{-# LANGUAGE FlexibleContexts       #-}
+{-# LANGUAGE KindSignatures         #-}
+{-# LANGUAGE NoImplicitPrelude      #-}
+{-# LANGUAGE TypeFamilies           #-}
+{-# LANGUAGE TypeFamilyDependencies #-}
+{-# LANGUAGE TypeOperators          #-}
+
+module Clash.Signal.Delayed.Bundle (
+  Bundle,
+  Unbundled,
+  bundle,
+  unbundle,
+  ) where
+
+import           Control.Applicative           (liftA2)
+import           GHC.TypeLits                  (KnownNat)
+import           Prelude                       hiding (head, map, tail)
+
+import           Clash.Explicit.Signal.Delayed (DSignal, toSignal,
+                                                unsafeFromSignal)
+import qualified Clash.Signal.Bundle           as B
+
+import           Clash.Signal.Internal         (Domain)
+import           Clash.Sized.BitVector         (Bit, BitVector)
+import           Clash.Sized.Fixed             (Fixed)
+import           Clash.Sized.Index             (Index)
+import           Clash.Sized.RTree             (RTree, lazyT)
+import           Clash.Sized.Signed            (Signed)
+import           Clash.Sized.Unsigned          (Unsigned)
+import           Clash.Sized.Vector            (Vec, lazyV)
+
+import           GHC.TypeLits                  (Nat)
+
+-- | Isomorphism between a 'Clash.Explicit.Signal.Delayed' of a product type
+-- (e.g. a tuple) and a product type of 'Clash.Explicit.Signal.Delayed''s.
+--
+-- Instances of 'Bundle' must satisfy the following laws:
+--
+-- @
+-- 'bundle' . 'unbundle' = 'id'
+-- 'unbundle' . 'bundle' = 'id'
+-- @
+--
+-- By default, 'bundle' and 'unbundle', are defined as the identity, that is,
+-- writing:
+--
+-- @
+-- data D = A | B
+--
+-- instance Bundle D
+-- @
+--
+-- is the same as:
+--
+-- @
+-- data D = A | B
+--
+-- instance Bundle D where
+--   type 'Unbundled'' domain delay D = 'DSignal'' domain d D
+--   'bundle'   _ s = s
+--   'unbundle' _ s = s
+-- @
+--
+class Bundle a where
+  type Unbundled (domain :: Domain) (d :: Nat) a = res | res -> domain d
+  type Unbundled domain d a = DSignal domain d a
+
+  -- | Example:
+  --
+  -- @
+  -- __bundle__ :: ('DSignal' domain d a, 'DSignal' domain d b) -> 'DSignal' clk d (a,b)
+  -- @
+  --
+  -- However:
+  --
+  -- @
+  -- __bundle__ :: 'DSignal' domain 'Clash.Sized.BitVector.Bit' -> 'DSignal' domain 'Clash.Sized.BitVector.Bit'
+  -- @
+  bundle :: Unbundled domain d a -> DSignal domain d a
+  {-# INLINE bundle #-}
+  default bundle :: (DSignal domain d a ~ Unbundled domain d a)
+                 => Unbundled domain d a -> DSignal domain d a
+  bundle s = s
+  -- | Example:
+  --
+  -- @
+  -- __unbundle__ :: 'DSignal' domain d (a,b) -> ('DSignal' domain d a, 'DSignal' domain d b)
+  -- @
+  --
+  -- However:
+  --
+  -- @
+  -- __unbundle__ :: 'DSignal' domain 'Clash.Sized.BitVector.Bit' -> 'DSignal' domain 'Clash.Sized.BitVector.Bit'
+  -- @
+  unbundle :: DSignal domain d a -> Unbundled domain d a
+  {-# INLINE unbundle #-}
+  default unbundle :: (Unbundled domain d a ~ DSignal domain d a)
+                   => DSignal domain d a -> Unbundled domain d a
+  unbundle s = s
+
+instance Bundle Bool
+instance Bundle Integer
+instance Bundle Int
+instance Bundle Float
+instance Bundle Double
+instance Bundle (Maybe a)
+instance Bundle (Either a b)
+
+instance Bundle Bit
+instance Bundle (BitVector n)
+instance Bundle (Index n)
+instance Bundle (Fixed rep int frac)
+instance Bundle (Signed n)
+instance Bundle (Unsigned n)
+
+instance Bundle (a,b) where
+  type Unbundled t delay (a,b) = (DSignal t delay a, DSignal t delay b)
+
+  bundle       = uncurry (liftA2 (,))
+  unbundle tup = (fmap fst tup, fmap snd tup)
+
+instance Bundle (a,b,c) where
+  type Unbundled t delay (a,b,c) =
+    ( DSignal t delay a, DSignal t delay b, DSignal t delay c)
+
+  bundle   (a,b,c) = (,,) <$> a <*> b <*> c
+  unbundle tup     = (fmap (\(x,_,_) -> x) tup
+                      ,fmap (\(_,x,_) -> x) tup
+                      ,fmap (\(_,_,x) -> x) tup
+                      )
+instance Bundle (a,b,c,d) where
+  type Unbundled t delay (a,b,c,d) =
+    ( DSignal t delay a, DSignal t delay b, DSignal t delay c, DSignal t delay d)
+
+  bundle   (a,b,c,d) = (,,,) <$> a <*> b <*> c <*> d
+  unbundle tup     = (fmap (\(x,_,_,_) -> x) tup
+                      ,fmap (\(_,x,_,_) -> x) tup
+                      ,fmap (\(_,_,x,_) -> x) tup
+                      ,fmap (\(_,_,_,x) -> x) tup
+                      )
+
+instance Bundle (a,b,c,d,e) where
+  type Unbundled t delay (a,b,c,d,e) =
+    ( DSignal t delay a, DSignal t delay b, DSignal t delay c, DSignal t delay d
+    , DSignal t delay e)
+
+  bundle   (a,b,c,d,e) = (,,,,) <$> a <*> b <*> c <*> d <*> e
+  unbundle tup     = (fmap (\(x,_,_,_,_) -> x) tup
+                      ,fmap (\(_,x,_,_,_) -> x) tup
+                      ,fmap (\(_,_,x,_,_) -> x) tup
+                      ,fmap (\(_,_,_,x,_) -> x) tup
+                      ,fmap (\(_,_,_,_,x) -> x) tup
+                      )
+
+instance Bundle (a,b,c,d,e,f) where
+  type Unbundled t delay (a,b,c,d,e,f) =
+    ( DSignal t delay a, DSignal t delay b, DSignal t delay c, DSignal t delay d
+    , DSignal t delay e, DSignal t delay f)
+
+  bundle   (a,b,c,d,e,f) = (,,,,,) <$> a <*> b <*> c <*> d <*> e <*> f
+  unbundle tup           = (fmap (\(x,_,_,_,_,_) -> x) tup
+                           ,fmap (\(_,x,_,_,_,_) -> x) tup
+                           ,fmap (\(_,_,x,_,_,_) -> x) tup
+                           ,fmap (\(_,_,_,x,_,_) -> x) tup
+                           ,fmap (\(_,_,_,_,x,_) -> x) tup
+                           ,fmap (\(_,_,_,_,_,x) -> x) tup
+                           )
+
+instance Bundle (a,b,c,d,e,f,g) where
+  type Unbundled t delay (a,b,c,d,e,f,g) =
+    ( DSignal t delay a, DSignal t delay b, DSignal t delay c, DSignal t delay d
+    , DSignal t delay e, DSignal t delay f, DSignal t delay g)
+
+  bundle   (a,b,c,d,e,f,g) = (,,,,,,) <$> a <*> b <*> c <*> d <*> e <*> f
+                                      <*> g
+  unbundle tup             = (fmap (\(x,_,_,_,_,_,_) -> x) tup
+                             ,fmap (\(_,x,_,_,_,_,_) -> x) tup
+                             ,fmap (\(_,_,x,_,_,_,_) -> x) tup
+                             ,fmap (\(_,_,_,x,_,_,_) -> x) tup
+                             ,fmap (\(_,_,_,_,x,_,_) -> x) tup
+                             ,fmap (\(_,_,_,_,_,x,_) -> x) tup
+                             ,fmap (\(_,_,_,_,_,_,x) -> x) tup
+                             )
+
+instance Bundle (a,b,c,d,e,f,g,h) where
+  type Unbundled t delay (a,b,c,d,e,f,g,h) =
+    ( DSignal t delay a, DSignal t delay b, DSignal t delay c, DSignal t delay d
+    , DSignal t delay e, DSignal t delay f ,DSignal t delay g, DSignal t delay h)
+
+  bundle   (a,b,c,d,e,f,g,h) = (,,,,,,,) <$> a <*> b <*> c <*> d <*> e <*> f
+                                         <*> g <*> h
+  unbundle tup               = (fmap (\(x,_,_,_,_,_,_,_) -> x) tup
+                               ,fmap (\(_,x,_,_,_,_,_,_) -> x) tup
+                               ,fmap (\(_,_,x,_,_,_,_,_) -> x) tup
+                               ,fmap (\(_,_,_,x,_,_,_,_) -> x) tup
+                               ,fmap (\(_,_,_,_,x,_,_,_) -> x) tup
+                               ,fmap (\(_,_,_,_,_,x,_,_) -> x) tup
+                               ,fmap (\(_,_,_,_,_,_,x,_) -> x) tup
+                               ,fmap (\(_,_,_,_,_,_,_,x) -> x) tup
+                               )
+
+instance KnownNat n => Bundle (Vec n a) where
+  type Unbundled t d (Vec n a) = Vec n (DSignal t d a)
+  bundle   = unsafeFromSignal . B.bundle . fmap toSignal
+  unbundle = sequenceA . fmap lazyV
+
+instance KnownNat d => Bundle (RTree d a) where
+  type Unbundled t delay (RTree d a) = RTree d (DSignal t delay a)
+  bundle   = sequenceA
+  unbundle = sequenceA . fmap lazyT
+

--- a/src/Clash/Signal/Delayed/Extra.hs
+++ b/src/Clash/Signal/Delayed/Extra.hs
@@ -1,0 +1,86 @@
+{-# LANGUAGE DataKinds              #-}
+{-# LANGUAGE FlexibleContexts       #-}
+{-# LANGUAGE KindSignatures         #-}
+{-# LANGUAGE MultiParamTypeClasses  #-}
+{-# LANGUAGE ScopedTypeVariables    #-}
+{-# LANGUAGE TypeFamilies           #-}
+{-# LANGUAGE TypeFamilyDependencies #-}
+{-# LANGUAGE TypeOperators          #-}
+{-# LANGUAGE UndecidableInstances   #-}
+
+{-# OPTIONS_GHC -fplugin GHC.TypeLits.Normalise       #-}
+{-# OPTIONS_GHC -fplugin GHC.TypeLits.KnownNat.Solver #-}
+
+module Clash.Signal.Delayed.Extra (
+  delay,
+  delayI,
+  pipelineTreeFold,
+  ) where
+
+
+import           Clash.Explicit.Signal.Delayed (DSignal, toSignal,
+                                                unsafeFromSignal)
+import           Clash.Signal                  (HiddenClock)
+import qualified Clash.Signal                  as S (delay)
+import           Clash.Signal.Internal         (Domain)
+
+import           Clash.Sized.Vector            (Vec, dtfold)
+
+import           Clash.Promoted.Nat
+
+import           Data.Proxy
+import           Data.Singletons.Prelude
+
+import           GHC.TypeLits                  (KnownNat, Nat)
+
+import           Clash.XException              (maybeX)
+
+-- | Delay a 'DSignal' for one cycle, the value at time 0 is /undefined/.
+--
+-- >>> fmap maybeX $ sampleN 6 (toSignal (delay (dfromList [1..])))
+-- [Nothing,Just 1,Just 2,Just 3,Just 4,Just 5]
+delay :: (HiddenClock domain gated)
+             => DSignal domain delay a
+             -> DSignal domain (delay+1) a
+delay = unsafeFromSignal . S.delay . toSignal
+
+-- | Delay a 'DSignal' for an implicit number of cycles, the value at time 0 is
+-- /undefined/.
+--
+-- @
+-- delay2 :: ('HiddenClock' domain gated)
+--        => 'DSignal' domain n Int -> 'DSignal' domain (n + 2) Int
+-- delay2 = 'delayI'
+-- @
+--
+-- >>> fmap maybeX $ sampleN 6 (toSignal (delay2 (dfromList [1..])))
+-- [Nothing,Nothing,Just 1,Just 2,Just 3,Just 4]
+delayI :: forall domain gated delay k a.
+              ( HiddenClock domain gated
+              , KnownNat k)
+              => DSignal domain delay     a
+              -> DSignal domain (delay+k) a
+delayI = unsafeFromSignal . go (snatToInteger (SNat :: SNat k)) . toSignal
+  where
+    go 0 = id
+    go n = S.delay . go (n-1)
+
+data DelayDSignal (domain :: Domain) (d :: Nat) (a :: *) (f :: TyFun Nat *) :: *
+type instance Apply (DelayDSignal domain d a) k = DSignal domain (d+k) a
+
+-- | A tree structured fold that inserts a flip-flop after every operation.
+pipelineTreeFold :: forall domain gated delay k a.
+                  ( HiddenClock domain gated
+                  , KnownNat delay
+                  , KnownNat k
+                  , KnownNat (2^k))
+                 => (a -> a -> a)                      -- ^ Fold operation to apply
+                 -> Vec (2^k) (DSignal domain delay a) -- ^ 2^k vector input
+                 -> DSignal domain (delay + k) a       -- ^ Output delayed by k
+pipelineTreeFold op = dtfold (Proxy :: Proxy (DelayDSignal domain delay a)) id go
+  where
+    go :: SNat l
+       -> DSignal domain (delay + l) a
+       -> DelayDSignal domain delay a @@ l
+       -> DelayDSignal domain delay a @@ (l+1)
+    go SNat x y = delay (op <$> x <*> y)


### PR DESCRIPTION
This adds DSignal functions that shadow Signal corresponding functions (but doesn't export them in the prelude of course):

 - a new DSignal based Bundle variant- the motivation being that working with the Signal version with DSignal types requires a lot of toSignal coercion. 
- 'delay' for DSignal (e.g. 'delayed' with undefined initial value, that doesn't require explicit reset)
- 'pipelineTreeFold' which provides a tree structured fold that inserts a flip-flop after every fold operation.

There are alternatives to the DSignal Bundle such as merging with the existing class (which I'm not sure can be done without breaking downstream work), a prelude exported non-shadowing name or perhaps keeping this as a separate package.   
