### PR TITLE
Add Bundle and BitPack instances for all the tuples (via TH)

### DIFF
--- a/clash-prelude.cabal
+++ b/clash-prelude.cabal
@@ -161,6 +161,7 @@ Library
                       Clash.Examples
 
   other-modules:      Clash.Class.BitPack.Internal
+                      Clash.Signal.Bundle.Internal
 
   other-extensions:   CPP
                       BangPatterns

--- a/clash-prelude.cabal
+++ b/clash-prelude.cabal
@@ -160,6 +160,8 @@ Library
                       Clash.Tutorial
                       Clash.Examples
 
+  other-modules:      Clash.Class.BitPack.Internal
+
   other-extensions:   CPP
                       BangPatterns
                       ConstraintKinds

--- a/src/Clash/Class/BitPack.hs
+++ b/src/Clash/Class/BitPack.hs
@@ -11,6 +11,7 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 {-# LANGUAGE FlexibleContexts     #-}
 {-# LANGUAGE MagicHash            #-}
 {-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE TemplateHaskell      #-}
 {-# LANGUAGE TypeFamilies         #-}
 {-# LANGUAGE TypeOperators        #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -42,6 +43,7 @@ import Numeric.Half                   (Half (..))
 import GHC.Generics
 import Prelude                        hiding (map)
 
+import Clash.Class.BitPack.Internal   (deriveBitPackTuples)
 import Clash.Class.Resize             (zeroExtend)
 import Clash.Sized.BitVector
   (Bit, BitVector, (++#), high, low)
@@ -224,42 +226,6 @@ instance (KnownNat (BitSize b), BitPack a, BitPack b) =>
   pack (a,b) = pack a ++# pack b
   unpack ab  = let (a,b) = split# ab in (unpack a, unpack b)
 
-instance (KnownNat (BitSize c), BitPack (a,b), BitPack c) =>
-    BitPack (a,b,c) where
-  type BitSize (a,b,c) = BitSize (a,b) + BitSize c
-  pack (a,b,c) = pack (a,b) ++# pack c
-  unpack (unpack -> ((a,b), c)) = (a,b,c)
-
-instance (KnownNat (BitSize d), BitPack (a,b,c), BitPack d) =>
-    BitPack (a,b,c,d) where
-  type BitSize (a,b,c,d) = BitSize (a,b,c) + BitSize d
-  pack (a,b,c,d) = pack (a,b,c) ++# pack d
-  unpack (unpack -> ((a,b,c), d)) = (a,b,c,d)
-
-instance (KnownNat (BitSize e), BitPack (a,b,c,d), BitPack e) =>
-    BitPack (a,b,c,d,e) where
-  type BitSize (a,b,c,d,e) = BitSize (a,b,c,d) + BitSize e
-  pack (a,b,c,d,e) = pack (a,b,c,d) ++# pack e
-  unpack (unpack -> ((a,b,c,d), e)) = (a,b,c,d,e)
-
-instance (KnownNat (BitSize f), BitPack (a,b,c,d,e), BitPack f) =>
-    BitPack (a,b,c,d,e,f) where
-  type BitSize (a,b,c,d,e,f) = BitSize (a,b,c,d,e) + BitSize f
-  pack (a,b,c,d,e,f) = pack (a,b,c,d,e) ++# pack f
-  unpack (unpack -> ((a,b,c,d,e), f)) = (a,b,c,d,e,f)
-
-instance (KnownNat (BitSize g), BitPack (a,b,c,d,e,f), BitPack g) =>
-    BitPack (a,b,c,d,e,f,g) where
-  type BitSize (a,b,c,d,e,f,g) = BitSize (a,b,c,d,e,f) + BitSize g
-  pack (a,b,c,d,e,f,g) = pack (a,b,c,d,e,f) ++# pack g
-  unpack (unpack -> ((a,b,c,d,e,f), g)) = (a,b,c,d,e,f,g)
-
-instance (KnownNat (BitSize h), BitPack (a,b,c,d,e,f,g), BitPack h) =>
-    BitPack (a,b,c,d,e,f,g,h) where
-  type BitSize (a,b,c,d,e,f,g,h) = BitSize (a,b,c,d,e,f,g) + BitSize h
-  pack (a,b,c,d,e,f,g,h) = pack (a,b,c,d,e,f,g) ++# pack h
-  unpack (unpack -> ((a,b,c,d,e,f,g), h)) = (a,b,c,d,e,f,g,h)
-
 instance (BitPack a, KnownNat (BitSize a)) => BitPack (Maybe a) where
   type BitSize (Maybe a) = 1 + BitSize a
   pack Nothing  = pack# low ++# 0
@@ -309,3 +275,6 @@ boolToBit = bitCoerce
 -- | Convert a Bool to a Bit
 bitToBool :: Bit -> Bool
 bitToBool = bitCoerce
+
+-- Derive the BitPack instance for tuples of size 3 to 62
+deriveBitPackTuples ''BitPack ''BitSize 'pack 'unpack '(++#)

--- a/src/Clash/Class/BitPack/Internal.hs
+++ b/src/Clash/Class/BitPack/Internal.hs
@@ -1,0 +1,91 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module Clash.Class.BitPack.Internal where
+
+import           Control.Monad         (replicateM)
+import           Data.List             (foldl')
+import           GHC.TypeLits          (KnownNat)
+import           Language.Haskell.TH
+
+-- | Contruct all the tuple (starting at size 3) instances for BitPack.
+deriveBitPackTuples
+  :: Name
+  -- ^ BitPack
+  -> Name
+  -- ^ BitSize
+  -> Name
+  -- ^ pack
+  -> Name
+  -- ^ unpack
+  -> Name
+  -- ^ append (++#)
+  -> DecsQ
+deriveBitPackTuples bitPackName bitSizeName packName unpackName appendName = do
+  let bitPack  = ConT bitPackName
+      bitSize  = ConT bitSizeName
+      knownNat = ConT ''KnownNat
+      plus     = ConT $ mkName "+"
+
+  allNames <- replicateM 62 (newName "a")
+  x <- newName "x"
+  y <- newName "y"
+
+  pure $ flip map [3..62] $ \tupleNum ->
+    let names  = take tupleNum allNames
+        (v:vs) = fmap VarT names
+        tuple xs = foldl' AppT (TupleT $ length xs) xs
+
+        -- Instance declaration
+        context =
+          [ bitPack `AppT` v
+          , knownNat `AppT` (bitSize `AppT` v)
+          , bitPack `AppT` tuple vs
+          , knownNat `AppT` (bitSize `AppT` tuple vs)
+          ]
+        instTy = AppT bitPack $ tuple (v:vs)
+
+        -- Associated type BitSize
+        bitSizeTypeEq =
+          TySynEqn
+            [ tuple (v:vs) ]
+            $ plus `AppT` (bitSize `AppT` v) `AppT`
+              (bitSize `AppT` foldl AppT (TupleT $ tupleNum - 1) vs)
+        bitSizeType = TySynInstD bitSizeName bitSizeTypeEq
+
+        pack =
+          FunD
+            packName
+            [ Clause
+                [ TupP $ map VarP names ]
+                ( let (e:es) = map VarE names
+                  in NormalB $ AppE
+                    (VarE appendName `AppE` (VarE packName `AppE` e))
+                    (VarE packName `AppE` TupE es)
+                )
+                []
+            ]
+
+        unpack =
+          FunD
+            unpackName
+            [ Clause
+                [ VarP x ]
+                ( NormalB $
+                    let (p:ps) = map VarP names
+                    in
+                    LetE
+                      [ ValD
+                          ( TupP [ p, VarP y ] )
+                          ( NormalB $ VarE unpackName `AppE` VarE x )
+                          []
+                      , ValD
+                          ( TupP ps )
+                          ( NormalB $ VarE unpackName `AppE` VarE y )
+                          []
+                      ]
+                      ( TupE $ map VarE names )
+                )
+                []
+            ]
+
+    in InstanceD Nothing context instTy [bitSizeType, pack, unpack]

--- a/src/Clash/Signal/Bundle/Internal.hs
+++ b/src/Clash/Signal/Bundle/Internal.hs
@@ -1,0 +1,81 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module Clash.Signal.Bundle.Internal where
+
+import           Clash.Signal.Internal (Signal)
+import           Control.Monad         (replicateM)
+import           Data.List             (foldl')
+import           Language.Haskell.TH
+
+-- | Contruct all the tuple instances for Bundle.
+deriveBundleTuples
+  :: Name
+  -- ^ Bundle
+  -> Name
+  -- ^ Unbundled
+  -> Name
+  -- ^ bundle
+  -> Name
+  -- ^ unbundle
+  -> DecsQ
+deriveBundleTuples bundleTyName unbundledTyName bundleName unbundleName = do
+  let bundleTy = ConT bundleTyName
+      signal   = ConT ''Signal
+
+  allNames <- replicateM 62 (newName "a")
+  tempNames <- replicateM 62 (newName "b")
+  t <- newName "t"
+  x <- newName "x"
+  tup <- newName "tup"
+
+  pure $ flip map [2..62] $ \tupleNum ->
+    let names = take tupleNum allNames
+        temps = take tupleNum tempNames
+        vars  = fmap VarT names
+        tuple = foldl' AppT (TupleT tupleNum)
+
+        -- Instance declaration
+        instTy = AppT bundleTy $ tuple vars
+
+        -- Associated type Unbundled
+        unbundledTypeEq =
+          TySynEqn
+            [ VarT t, tuple vars ]
+            $ tuple $ map (AppT (signal `AppT` VarT t)) vars
+        unbundledType = TySynInstD unbundledTyName unbundledTypeEq
+
+        bundleLambda = LamE (map VarP temps) (TupE $ map VarE temps)
+        applicatives = VarE '(<$>) : repeat (VarE '(<*>))
+        bundle =
+          FunD
+            bundleName
+            [ Clause
+                [ TupP $ map VarP names ]
+                ( NormalB
+                $ foldl'
+                    (\f (a, b) -> a `AppE` f `AppE` b)
+                    bundleLambda
+                    (zip applicatives $ map VarE names)
+                )
+                []
+            ]
+
+        unbundleLambda n =
+          LamE
+            [ TupP [ if i == n then VarP x else WildP | i <- [0..tupleNum-1] ] ]
+            (VarE x)
+
+        unbundle =
+          FunD
+            unbundleName
+            [ Clause
+                [ VarP tup ]
+                ( NormalB . TupE $
+                    map 
+                      (\n -> VarE 'fmap `AppE` unbundleLambda n `AppE` VarE tup)
+                      [0..tupleNum-1]
+                )
+                []
+            ]
+
+    in InstanceD Nothing [] instTy [unbundledType, bundle, unbundle]


### PR DESCRIPTION
This PR removes the limit where only tuples smaller than size 8 have `Bundle` and `BitPack` instances.

Thanks to @cchalmers for the initial TH work that made these easier to write.

*Note*: This PR might have some effects on the time it takes to compile `clash-prelude`. The small amount of compilation I did seemed alright, but maybe other people should test it before we merge this.