### PR TITLE
inout ports

### DIFF
--- a/clash-prelude.cabal
+++ b/clash-prelude.cabal
@@ -136,6 +136,7 @@ Library
 
                       Clash.Signal
                       Clash.Signal.Bundle
+                      Clash.Signal.BiSignal
                       Clash.Signal.Delayed
                       Clash.Signal.Internal
 

--- a/src/Clash/Signal.hs
+++ b/src/Clash/Signal.hs
@@ -52,6 +52,9 @@ never create a clock that goes any faster!
 module Clash.Signal
   ( -- * Synchronous signals
     Signal
+  , BiSignalIn
+  , BiSignalOut
+  , BiSignalDefault(..)
   , Domain (..)
   , System
     -- * Clock
@@ -125,6 +128,11 @@ module Clash.Signal
   , (.==.), (./=.)
     -- ** 'Ord'-like
   , (.<.), (.<=.), (.>=.), (.>.)
+    -- * Bisignal functions
+  , veryUnsafeToBiSignalIn
+  , readFromBiSignal
+  , writeToBiSignal
+  , mergeBiSignalOuts
   )
 where
 
@@ -144,6 +152,7 @@ import           Clash.Hidden
 import           Clash.Promoted.Nat    (SNat (..))
 import           Clash.Promoted.Symbol (SSymbol (..))
 import           Clash.Signal.Bundle   (Bundle (..))
+import           Clash.Signal.BiSignal --(BisignalIn, BisignalOut, )
 import           Clash.Signal.Internal hiding
   (sample, sample_lazy, sampleN, sampleN_lazy, simulate, simulate_lazy, testFor)
 import qualified Clash.Signal.Internal as S

--- a/src/Clash/Signal/BiSignal.hs
+++ b/src/Clash/Signal/BiSignal.hs
@@ -79,6 +79,8 @@ topEntity clk rst = readFromBiSignal bus'
     bus' = veryUnsafeToBiSignalIn bus
 @
 -}
+
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE TypeOperators #-}
@@ -158,12 +160,19 @@ data BiSignalIn (ds :: BiSignalDefault) (dom :: Domain) (n :: Nat)
 newtype BiSignalOut (ds :: BiSignalDefault) (dom :: Domain) (n :: Nat)
   = BiSignalOut [Signal dom (Maybe (BitVector n))]
 
+#if MIN_VERSION_base(4,11,0)
+instance Semigroup (BiSignalOut defaultState dom n) where
+  (BiSignalOut b1) <> (BiSignalOut b2) = BiSignalOut (b1 ++ b2)
+#endif
+
 -- | Monoid instance to support concatenating
 --
 -- __NB__ Not synthesizable
 instance Monoid (BiSignalOut defaultState dom n) where
   mempty                                    = BiSignalOut []
+#if !MIN_VERSION_base(4,11,0)
   mappend (BiSignalOut b1) (BiSignalOut b2) = BiSignalOut $ b1 ++ b2
+#endif
 
 -- /Lazily/ prepend a value to a 'BiSignalIn'.
 --

--- a/src/Clash/Signal/BiSignal.hs
+++ b/src/Clash/Signal/BiSignal.hs
@@ -1,0 +1,206 @@
+{-|
+Copyright  :  (C) 2017, Google Inc.
+                  2017, QBayLogic
+License    :  BSD2 (see the file LICENSE)
+Author     :  Martijn Bastiaan <martijn@qbaylogic.com>
+Maintainer :  Christiaan Baaij <christiaan@qbaylogic.com>
+
+Although wires in hardware are fundamentally bidirectional, most HDLs and simulation software distinguishes between
+'in' and 'out' signals. Wires which are explicitly marked as 'inout' will remain bidirectional however. Clash has
+support for 'inout' ports through the implementation of /BiSignal/s. To cleanly map to functions (and thus support
+software simulation using Haskell), a BiSignal comes in two parts; the in part:
+
+@
+'BiSignalIn' (ds :: 'BiSignalDefault') (dom :: 'Domain') a
+@
+
+and the out part:
+
+@
+'BiSignalOut' (ds :: 'BiSignalDefault') (dom :: 'Domain') a
+@
+
+Where /a/ is the type of the value of the BiSignal, for example /Int/ or /Bool/, and /domain/ is the /clock-/
+(and /reset-/) domain to which the memory elements manipulating these BiSignals belong. Lastly, /ds/ indicates
+the default behavior for the BiSignal if nothing is being written (pull-down, pull-up, or undefined).
+
+/BiSignalIn/ is used by Clash to generate the 'inout' ports on a HDL level, while /BiSignalOut/ is only used
+for simulation purposes and generally discarded by the compiler.
+
+-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE FlexibleContexts #-}
+
+{-# OPTIONS_GHC -fplugin=GHC.TypeLits.Extra.Solver #-}
+{-# OPTIONS_GHC -fplugin=GHC.TypeLits.Normalise #-}
+{-# OPTIONS_GHC -fplugin=GHC.TypeLits.KnownNat.Solver #-}
+
+module Clash.Signal.BiSignal (
+    BiSignalIn()
+  , BiSignalOut()
+  , BiSignalDefault(..)
+  , mergeBiSignalOuts
+  , readFromBiSignal
+  , writeToBiSignal
+  , veryUnsafeToBiSignalIn
+  ) where
+
+import           Type.Reflection            (Typeable, typeOf, splitApps)
+import           Data.Maybe                 (Maybe,fromMaybe,fromJust,isJust)
+import           Data.List                  (intercalate)
+
+import qualified Clash.Sized.Vector         as V
+import           Clash.Sized.Vector         (Vec)
+import           Clash.Signal.Internal      (Signal(..), Domain, foldr#)
+import           Clash.Class.BitPack        (BitPack, BitSize, unpack)
+import           Clash.XException           (errorX)
+
+import           GHC.TypeLits               (KnownNat)
+import           GHC.Stack                  (HasCallStack)
+
+-- | Used to specify default behaviour on reading from a BiSignal
+data BiSignalDefault = High
+                     -- ^ inout behaves as if connected to a pull-up resistor
+                     | Low
+                     -- ^ inout behaves as if connected to a pull-down resistor
+                     | Undefined
+                     -- ^ inout behaves as if it has a floating signal if not written to. Evaluation such a value in
+                     --   simulation will yield an errorX (undefined value).
+                      deriving (Typeable,Show)
+
+-- |
+data BiSignalIn (ds :: BiSignalDefault) (dom :: Domain) a where
+    BiSignalIn :: ( KnownNat m
+                  , m ~ BitSize a
+                  , BitPack a
+                  -- Typeable instances in order to implement default#:
+                  , Typeable a
+                  , Typeable ds
+                  , Typeable dom
+                  )
+               => Signal dom (Maybe a)
+               -> BiSignalIn ds dom a
+                    deriving (Typeable)
+
+-- | Wraps (multiple) writing signals. The semantics are such that only one of the signals may write
+--   at a single time step.
+newtype BiSignalOut (ds :: BiSignalDefault) (dom :: Domain) a = BiSignalOut [Signal dom (Maybe a)]
+
+-- | Monoid instance to support concatting
+instance Monoid (BiSignalOut defaultState dom a) where
+   mempty                                    = BiSignalOut []
+   mappend (BiSignalOut b1) (BiSignalOut b2) = BiSignalOut $ b1 ++ b2
+
+-- | Foldable instance to support sampling from BiSignals
+instance Foldable (BiSignalIn ds dom) where
+  foldr f z bi = foldr# f z (readFromBiSignal bi)
+
+-- Helper functions for this module only:
+prepend# :: ( KnownNat m
+            , m ~ BitSize a
+            , BitPack a
+            , Typeable a
+            , Typeable ds
+            , Typeable d
+            )
+         => Maybe a
+         -> BiSignalIn ds d a
+         -> BiSignalIn ds d a
+prepend# a bsi = BiSignalIn (a :- as)
+  where
+    -- Move deconstruction to increase laziness:
+    as = case bsi of (BiSignalIn as') -> as'
+
+head# :: Signal dom a -> a
+head# (x' :- _ )  = x'
+
+tail# :: Signal dom a -> Signal dom a
+tail# (_  :- xs') = xs'
+
+-- | Will determine the default value of an "undefined" value based on the type of the
+--   BiSignal given using reflection.
+default# :: BiSignalIn ds d a -> BiSignalDefault
+default# t@(BiSignalIn _) = let (_, [ds, _, _]) = splitApps (typeOf t) in case tail $ show ds of
+                                                                              "High"      -> High
+                                                                              "Low"       -> Low
+                                                                              "Undefined" -> Undefined
+                                                                              _           -> error "Unreachable code in default# in Clash.Signal.BiSignal"
+-- / Helper functions
+
+{-# NOINLINE readFromBiSignal #-}
+readFromBiSignal :: HasCallStack
+                 => BiSignalIn ds d a
+                 -> Signal d a
+readFromBiSignal t@(BiSignalIn s) =
+  case default# t of
+    Undefined -> fromMaybe (errorX " undefined value on BiSignalIn") <$> s
+    Low       -> fromMaybe (unpack minBound) <$> s
+    High      -> fromMaybe (unpack maxBound) <$> s
+
+
+{-# NOINLINE mergeBiSignalOuts #-}
+-- | Combine several inout signals into one.
+mergeBiSignalOuts :: ( HasCallStack
+                     , Show a
+                     , KnownNat n
+                     )
+                  => Vec n (BiSignalOut defaultState dom a)
+                  -> BiSignalOut defaultState dom a
+mergeBiSignalOuts = mconcat . V.toList
+
+{-# NOINLINE writeToBiSignal# #-}
+writeToBiSignal# :: HasCallStack
+                 => BiSignalIn ds d a
+                 -> Signal d (Maybe a)
+                 -> Signal d Bool
+                 -> Signal d a
+                 -> BiSignalOut ds d a
+writeToBiSignal# _ maybeSignal _ _ = BiSignalOut [maybeSignal]
+
+-- | Create a BiSignalOut
+writeToBiSignal :: HasCallStack
+                => BiSignalIn ds d a
+                -> Signal d (Maybe a)
+                -- ^ Value to write
+                -> BiSignalOut ds d a
+writeToBiSignal input writes = writeToBiSignal# input writes (isJust <$> writes) (fromJust <$> writes)
+
+{-# NOINLINE veryUnsafeToBiSignalIn #-}
+-- | Converts the 'out' part of a BiSignal to an 'in' part. In simulation it checks whether multiple components are
+--   writing and will err accordingly. Make sure this is only called ONCE for every BiSignal.
+veryUnsafeToBiSignalIn :: ( HasCallStack
+                          , Show a
+                          , KnownNat m
+                          , m ~ BitSize a
+                          , BitPack a
+                          , Typeable a
+                          , Typeable ds
+                          , Typeable d
+                          )
+                       => BiSignalOut ds d a
+                       -> BiSignalIn ds d a
+veryUnsafeToBiSignalIn (BiSignalOut signals) = prepend# result biSignalOut'
+  where
+    -- Enforce that only one component is writing
+    writing = filter (isJust . head#) signals
+    result | null writing        = Nothing
+           | length writing == 1 = head# $ head writing
+           | otherwise           = error err
+
+    -- FIXME: Use ClashException? Use errorX? Use error?
+    err = "Multiple components wrote to the BiSignal. This is undefined behavior in "
+       ++ "hardware and almost certainly a logic error. The components wrote: \n  "
+       ++ intercalate "\n  " (map (show . head#) signals)
+
+    -- Recursive step
+    biSignalOut' = veryUnsafeToBiSignalIn $ BiSignalOut $ map tail# signals

--- a/src/Clash/Signal/BiSignal.hs
+++ b/src/Clash/Signal/BiSignal.hs
@@ -235,6 +235,7 @@ writeToBiSignal input writes =
     (fmap pack <$> writes)
     (isJust <$> writes)
     (pack . fromJust <$> writes)
+{-# INLINE writeToBiSignal #-}
 
 -- | Converts the 'out' part of a BiSignal to an 'in' part. In simulation it
 -- checks whether multiple components are writing and will error accordingly.

--- a/src/Clash/Signal/BiSignal.hs
+++ b/src/Clash/Signal/BiSignal.hs
@@ -1,32 +1,83 @@
 {-|
 Copyright  :  (C) 2017, Google Inc.
-                  2017, QBayLogic
 License    :  BSD2 (see the file LICENSE)
-Author     :  Martijn Bastiaan <martijn@qbaylogic.com>
-Maintainer :  Christiaan Baaij <christiaan@qbaylogic.com>
+Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 
-Although wires in hardware are fundamentally bidirectional, most HDLs and simulation software distinguishes between
-'in' and 'out' signals. Wires which are explicitly marked as 'inout' will remain bidirectional however. Clash has
-support for 'inout' ports through the implementation of /BiSignal/s. To cleanly map to functions (and thus support
-software simulation using Haskell), a BiSignal comes in two parts; the in part:
+Wires are fundamentally bidirectional, and in traditional HDLs we can exploit
+this aspect by explicitly marking the endpoint, or port, of such a wire as
+/inout/, thereby making this port function as both a source and a drain for the
+signals flowing over the wire.
 
-@
-'BiSignalIn' (ds :: 'BiSignalDefault') (dom :: 'Domain') a
-@
-
-and the out part:
+Clash has support for 'inout' ports through the implementation of /BiSignal/s.
+To cleanly map to functions (and thus support software simulation using Haskell),
+a /BiSignal/ comes in two parts; the __in__ part:
 
 @
-'BiSignalOut' (ds :: 'BiSignalDefault') (dom :: 'Domain') a
+'BiSignalIn' (ds :: 'BiSignalDefault') (dom :: 'Domain') (n :: Nat)
 @
 
-Where /a/ is the type of the value of the BiSignal, for example /Int/ or /Bool/, and /domain/ is the /clock-/
-(and /reset-/) domain to which the memory elements manipulating these BiSignals belong. Lastly, /ds/ indicates
-the default behavior for the BiSignal if nothing is being written (pull-down, pull-up, or undefined).
+and the __out__ part:
 
-/BiSignalIn/ is used by Clash to generate the 'inout' ports on a HDL level, while /BiSignalOut/ is only used
-for simulation purposes and generally discarded by the compiler.
+@
+'BiSignalOut' (ds :: 'BiSignalDefault') (dom :: 'Domain') (n :: Nat)
+@
 
+Where:
+
+  * The internal representation is a 'BitVector'
+  * /n/ indicates the number of bits in the 'BitVector'
+  * /domain/ is the /clock-/ (and /reset-/) domain to which the memory elements
+    manipulating these BiSignals belong.
+  * Lastly, /ds/ indicates the default behavior for the BiSignal if nothing is
+    being written (pull-down, pull-up, or undefined).
+
+'BiSignalIn' is used by Clash to generate the 'inout' ports on a HDL level,
+while 'BiSignalOut' is only used for simulation purposes and generally discarded
+by the compiler.
+
+= Example
+
+The following describes a system where two circuits, in alternating fashion,
+read the current value from the /bus/, increment it, and write it on the next
+cycle.
+
+@
+-- | Alternatively read / increment+write
+counter :: (Bool, Int)
+        -- ^ Internal flip + previous read
+        -> Int
+        -- ^ Int from inout
+        -> ((Bool, Int), Maybe Int)
+counter (write, prevread) i = ((write', prevread'), output)
+  where
+    output    = if write then Just (succ prevread) else Nothing
+    prevread' = if write then prevread else i
+    write' = not write
+
+-- | Write on odd cyles
+f :: Clock System Source
+  -> Reset System Asynchronous
+  -> BiSignalIn  Undefined System (BitSize Int)
+  -> BiSignalOut Undefined System (BitSize Int)
+f clk rst s = writeToBiSignal s (mealy clk rst counter (False, 0) (readFromBiSignal s))
+
+-- | Write on even cyles
+g :: Clock System Source
+  -> Reset System Asynchronous
+  -> BiSignalIn  Undefined System (BitSize Int)
+  -> BiSignalOut Undefined System (BitSize Int)
+g clk rst s = writeToBiSignal s (mealy clk rst counter (True, 0) (readFromBiSignal s))
+
+
+-- | Connect the /f/ and /g/ circuits to the same bus
+topEntity :: Clock System Source
+          -> Reset System Asynchronous
+          -> Signal System Int
+topEntity clk rst = readFromBiSignal bus'
+  where
+    bus  = mergeBiSignalOuts $ f clk rst bus' :> g clk rst bus' :> Nil
+    bus' = veryUnsafeToBiSignalIn bus
+@
 -}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE MagicHash #-}
@@ -55,152 +106,160 @@ module Clash.Signal.BiSignal (
   , veryUnsafeToBiSignalIn
   ) where
 
-import           Type.Reflection            (Typeable, typeOf, splitApps)
 import           Data.Maybe                 (Maybe,fromMaybe,fromJust,isJust)
 import           Data.List                  (intercalate)
 
+import           Clash.Class.BitPack        (BitPack (..))
+import           Clash.Sized.BitVector      (BitVector)
 import qualified Clash.Sized.Vector         as V
 import           Clash.Sized.Vector         (Vec)
-import           Clash.Signal.Internal      (Signal(..), Domain, foldr#)
-import           Clash.Class.BitPack        (BitPack, BitSize, unpack)
+import           Clash.Signal.Internal      (Signal(..), Domain, head#, tail#)
 import           Clash.XException           (errorX)
 
-import           GHC.TypeLits               (KnownNat)
+import           GHC.TypeLits               (KnownNat, Nat)
 import           GHC.Stack                  (HasCallStack)
+import           Data.Reflection            (Given (..))
 
--- | Used to specify default behaviour on reading from a BiSignal
-data BiSignalDefault = High
-                     -- ^ inout behaves as if connected to a pull-up resistor
-                     | Low
-                     -- ^ inout behaves as if connected to a pull-down resistor
-                     | Undefined
-                     -- ^ inout behaves as if it has a floating signal if not written to. Evaluation such a value in
-                     --   simulation will yield an errorX (undefined value).
-                      deriving (Typeable,Show)
+-- | Used to specify the /default/ behavior of a 'BiSignal', i.e. what value is
+-- read when no value is being written to it.
+data BiSignalDefault
+  = PullUp
+  -- ^ __inout__ port behaves as if connected to a pull-up resistor
+  | PullDown
+  -- ^ __inout__ port behaves as if connected to a pull-down resistor
+  | Undefined
+  -- ^ __inout__ port behaves as if is /floating/. Reading a /floating/
+  -- 'BiSignal' value in simulation will yield an errorX (undefined value).
+  deriving (Show)
 
--- |
-data BiSignalIn (ds :: BiSignalDefault) (dom :: Domain) a where
-    BiSignalIn :: ( KnownNat m
-                  , m ~ BitSize a
-                  , BitPack a
-                  -- Typeable instances in order to implement default#:
-                  , Typeable a
-                  , Typeable ds
-                  , Typeable dom
-                  )
-               => Signal dom (Maybe a)
-               -> BiSignalIn ds dom a
-                    deriving (Typeable)
+-- | Singleton versions of 'BiSignalDefault'
+data SBiSignalDefault :: BiSignalDefault -> * where
+  SPullUp    :: SBiSignalDefault 'PullUp
+  SPullDown  :: SBiSignalDefault 'PullDown
+  SUndefined :: SBiSignalDefault 'Undefined
 
--- | Wraps (multiple) writing signals. The semantics are such that only one of the signals may write
---   at a single time step.
-newtype BiSignalOut (ds :: BiSignalDefault) (dom :: Domain) a = BiSignalOut [Signal dom (Maybe a)]
+instance Given (SBiSignalDefault 'PullUp) where
+  given = SPullUp
 
--- | Monoid instance to support concatting
-instance Monoid (BiSignalOut defaultState dom a) where
-   mempty                                    = BiSignalOut []
-   mappend (BiSignalOut b1) (BiSignalOut b2) = BiSignalOut $ b1 ++ b2
+instance Given (SBiSignalDefault 'PullDown) where
+  given = SPullDown
 
--- | Foldable instance to support sampling from BiSignals
-instance Foldable (BiSignalIn ds dom) where
-  foldr f z bi = foldr# f z (readFromBiSignal bi)
+instance Given (SBiSignalDefault 'Undefined) where
+  given = SUndefined
 
--- Helper functions for this module only:
-prepend# :: ( KnownNat m
-            , m ~ BitSize a
-            , BitPack a
-            , Typeable a
-            , Typeable ds
-            , Typeable d
-            )
-         => Maybe a
-         -> BiSignalIn ds d a
-         -> BiSignalIn ds d a
-prepend# a bsi = BiSignalIn (a :- as)
-  where
-    -- Move deconstruction to increase laziness:
-    as = case bsi of (BiSignalIn as') -> as'
+-- | The /in/ part of an __inout__ port
+data BiSignalIn (ds :: BiSignalDefault) (dom :: Domain) (n :: Nat)
+  = BiSignalIn (SBiSignalDefault ds) (Signal dom (Maybe (BitVector n)))
 
-head# :: Signal dom a -> a
-head# (x' :- _ )  = x'
+-- | The /out/ part of an __inout__ port
+--
+-- Wraps (multiple) writing signals. The semantics are such that only one of
+-- the signals may write at a single time step.
+newtype BiSignalOut (ds :: BiSignalDefault) (dom :: Domain) (n :: Nat)
+  = BiSignalOut [Signal dom (Maybe (BitVector n))]
 
-tail# :: Signal dom a -> Signal dom a
-tail# (_  :- xs') = xs'
+-- | Monoid instance to support concatenating
+--
+-- __NB__ Not synthesizable
+instance Monoid (BiSignalOut defaultState dom n) where
+  mempty                                    = BiSignalOut []
+  mappend (BiSignalOut b1) (BiSignalOut b2) = BiSignalOut $ b1 ++ b2
 
--- | Will determine the default value of an "undefined" value based on the type of the
---   BiSignal given using reflection.
-default# :: BiSignalIn ds d a -> BiSignalDefault
-default# t@(BiSignalIn _) = let (_, [ds, _, _]) = splitApps (typeOf t) in case tail $ show ds of
-                                                                              "High"      -> High
-                                                                              "Low"       -> Low
-                                                                              "Undefined" -> Undefined
-                                                                              _           -> error "Unreachable code in default# in Clash.Signal.BiSignal"
--- / Helper functions
+-- /Lazily/ prepend a value to a 'BiSignalIn'.
+--
+-- Uses a /reified/ 'SBiSignalDefault', the 'Given' constraint, so we can fully
+-- create 'BiSignalIn' "out of nowhere" when dealing with circular definitions.
+prepend#
+  :: Given (SBiSignalDefault ds)
+  => Maybe (BitVector n)
+  -> BiSignalIn ds d n
+  -> BiSignalIn ds d n
+prepend# a ~(BiSignalIn _ as) = BiSignalIn given (a :- as)
 
-{-# NOINLINE readFromBiSignal #-}
-readFromBiSignal :: HasCallStack
-                 => BiSignalIn ds d a
-                 -> Signal d a
-readFromBiSignal t@(BiSignalIn s) =
-  case default# t of
-    Undefined -> fromMaybe (errorX " undefined value on BiSignalIn") <$> s
-    Low       -> fromMaybe (unpack minBound) <$> s
-    High      -> fromMaybe (unpack maxBound) <$> s
+readFromBiSignal#
+  :: ( HasCallStack
+     , KnownNat n)
+  => BiSignalIn ds d n
+  -> Signal d (BitVector n)
+readFromBiSignal# (BiSignalIn ds s) =
+  case ds of
+    SUndefined -> fromMaybe (errorX " undefined value on BiSignalIn") <$> s
+    SPullDown  -> fromMaybe minBound <$> s
+    SPullUp    -> fromMaybe maxBound <$> s
+{-# NOINLINE readFromBiSignal# #-}
 
+-- | Read the value from an __inout__ port
+readFromBiSignal
+  :: ( HasCallStack
+     , KnownNat (BitSize a)
+     , BitPack a)
+  => BiSignalIn ds d (BitSize a)
+  -- ^ A 'BiSignalIn' with a number of bits needed to represent /a/
+  -> Signal d a
+readFromBiSignal = fmap unpack . readFromBiSignal#
 
-{-# NOINLINE mergeBiSignalOuts #-}
--- | Combine several inout signals into one.
-mergeBiSignalOuts :: ( HasCallStack
-                     , Show a
-                     , KnownNat n
-                     )
-                  => Vec n (BiSignalOut defaultState dom a)
-                  -> BiSignalOut defaultState dom a
+-- | Combine several __inout__ signals into one.
+mergeBiSignalOuts
+  :: ( HasCallStack
+     , KnownNat n
+     )
+  => Vec n (BiSignalOut defaultState dom m)
+  -> BiSignalOut defaultState dom m
 mergeBiSignalOuts = mconcat . V.toList
+{-# NOINLINE mergeBiSignalOuts #-}
 
-{-# NOINLINE writeToBiSignal# #-}
-writeToBiSignal# :: HasCallStack
-                 => BiSignalIn ds d a
-                 -> Signal d (Maybe a)
-                 -> Signal d Bool
-                 -> Signal d a
-                 -> BiSignalOut ds d a
+writeToBiSignal#
+  :: HasCallStack
+  => BiSignalIn ds d n
+  -> Signal d (Maybe (BitVector n))
+  -> Signal d Bool
+  -> Signal d (BitVector n)
+  -> BiSignalOut ds d n
+-- writeToBiSignal# = writeToBiSignal#
 writeToBiSignal# _ maybeSignal _ _ = BiSignalOut [maybeSignal]
+{-# NOINLINE writeToBiSignal# #-}
 
--- | Create a BiSignalOut
-writeToBiSignal :: HasCallStack
-                => BiSignalIn ds d a
-                -> Signal d (Maybe a)
-                -- ^ Value to write
-                -> BiSignalOut ds d a
-writeToBiSignal input writes = writeToBiSignal# input writes (isJust <$> writes) (fromJust <$> writes)
+-- | Write to an __inout__ port
+writeToBiSignal
+  :: (HasCallStack, BitPack a)
+  => BiSignalIn ds d (BitSize a)
+  -> Signal d (Maybe a)
+  -- ^ Value to write
+  --
+  --   * /Just a/ writes an /a/ value
+  --   * /Nothing/ puts the port in a /high-impedance/ state
+  -> BiSignalOut ds d (BitSize a)
+writeToBiSignal input writes =
+  writeToBiSignal#
+    input
+    (fmap pack <$> writes)
+    (isJust <$> writes)
+    (pack . fromJust <$> writes)
 
-{-# NOINLINE veryUnsafeToBiSignalIn #-}
--- | Converts the 'out' part of a BiSignal to an 'in' part. In simulation it checks whether multiple components are
---   writing and will err accordingly. Make sure this is only called ONCE for every BiSignal.
-veryUnsafeToBiSignalIn :: ( HasCallStack
-                          , Show a
-                          , KnownNat m
-                          , m ~ BitSize a
-                          , BitPack a
-                          , Typeable a
-                          , Typeable ds
-                          , Typeable d
-                          )
-                       => BiSignalOut ds d a
-                       -> BiSignalIn ds d a
+-- | Converts the 'out' part of a BiSignal to an 'in' part. In simulation it
+-- checks whether multiple components are writing and will error accordingly.
+-- Make sure this is only called ONCE for every BiSignal.
+veryUnsafeToBiSignalIn
+  :: ( HasCallStack
+     , KnownNat n
+     , Given (SBiSignalDefault ds)
+     )
+  => BiSignalOut ds d n
+  -> BiSignalIn ds d n
 veryUnsafeToBiSignalIn (BiSignalOut signals) = prepend# result biSignalOut'
   where
     -- Enforce that only one component is writing
-    writing = filter (isJust . head#) signals
-    result | null writing        = Nothing
-           | length writing == 1 = head# $ head writing
-           | otherwise           = error err
+    result = case filter (isJust . head#) signals of
+      []  -> Nothing
+      [w] -> head# w
+      _   -> errorX err
 
-    -- FIXME: Use ClashException? Use errorX? Use error?
-    err = "Multiple components wrote to the BiSignal. This is undefined behavior in "
-       ++ "hardware and almost certainly a logic error. The components wrote: \n  "
-       ++ intercalate "\n  " (map (show . head#) signals)
+    err = unwords
+      [ "Multiple components wrote to the BiSignal. This is undefined behavior"
+      , "in hardware and almost certainly a logic error. The components wrote:\n"
+      , intercalate "\n  " (map (show . head#) signals)
+      ]
 
     -- Recursive step
     biSignalOut' = veryUnsafeToBiSignalIn $ BiSignalOut $ map tail# signals
+{-# NOINLINE veryUnsafeToBiSignalIn #-}

--- a/src/Clash/Signal/Internal.hs
+++ b/src/Clash/Signal/Internal.hs
@@ -30,6 +30,8 @@ module Clash.Signal.Internal
   ( -- * Datatypes
     Domain (..)
   , Signal (..)
+  , head#
+  , tail#
     -- * Clocks
   , Clock (..)
   , ClockKind (..)
@@ -156,6 +158,12 @@ never create a clock that goes any faster!
 data Signal (domain :: Domain) a
   -- | The constructor, @(':-')@, is __not__ synthesisable.
   = a :- Signal domain a
+
+head# :: Signal dom a -> a
+head# (x' :- _ )  = x'
+
+tail# :: Signal dom a -> Signal dom a
+tail# (_  :- xs') = xs'
 
 instance Show a => Show (Signal domain a) where
   show (x :- xs) = show x ++ " " ++ show xs

--- a/src/Clash/Signal/Internal.hs
+++ b/src/Clash/Signal/Internal.hs
@@ -88,6 +88,7 @@ module Clash.Signal.Internal
   )
 where
 
+import Type.Reflection            (Typeable)
 import Control.Applicative        (liftA2, liftA3)
 import Control.DeepSeq            (NFData, force)
 import Control.Exception          (catch, evaluate, throw)
@@ -122,6 +123,7 @@ import Clash.XException           (Undefined (..), XException, errorX, seqX)
 
 -- | A domain with a name (@Symbol@) and a clock period (@Nat@) in /ps/
 data Domain = Dom { domainName :: Symbol, clkPeriod :: Nat }
+  deriving (Typeable)
 
 infixr 5 :-
 {- | CλaSH has synchronous 'Signal's in the form of:

--- a/src/Clash/Tutorial.hs
+++ b/src/Clash/Tutorial.hs
@@ -1277,6 +1277,9 @@ a general listing of the available template holes:
 * @~NAME[N]@: Render the @(N+1)@'th string literal argument as an identifier
   instead of a string literal. Fails when the @(N+1)@'th argument is not a
   string literal.
+* @~DEVNULL[\<HOLE\>]@: Render all dependencies of @\<HOLE\>@, but disregard direct output
+* @~REPEAT[\<HOLE\>][N]@: Repeat literal value of @\<HOLE\>@ a total of @N@ times.
+
 
 
 Some final remarks to end this section: VHDL primitives are there to instruct the


### PR DESCRIPTION
In traditional HDLs we can mark an endpoint, or port, of a wire as _inout_, thereby making this port function as both a source and a drain for the signals flowing over the wire.

Clash has support for 'inout' ports through the implementation of _BiSignal_s. To cleanly map to functions (and thus support software simulation using Haskell), a _BiSignal_ comes in two parts; the __in__ part:

```haskell
BiSignalIn (ds :: BiSignalDefault) (dom :: Domain) (n :: Nat)
```

and the __out__ part:

```haskell
BiSignalOut (ds :: BiSignalDefault) (dom :: Domain) (n :: Nat)
```

Where:

  * The internal representation is a `BitVector`
  * _n_ indicates the number of bits in the `BitVector`
  * _domain_ is the _clock-_ (and _reset-_) domain to which the memory elements manipulating these BiSignals belong.
  * Lastly, _ds_  indicates the default behavior for the BiSignal if nothing is being written (pull-down, pull-up, or undefined).

`BiSignalIn` is used by Clash to generate the `inout` ports on a HDL level, while `BiSignalOut` is only used for simulation purposes and generally discarded by the compiler.

## Example

The following describes a system where two circuits, in alternating fashion, read the current value from the /bus/, increment it, and write it on the next cycle.

```haskell
-- | Alternatively read / increment+write
counter :: (Bool, Int)
        -- ^ Internal flip + previous read
        -> Int
        -- ^ Int from inout
        -> ((Bool, Int), Maybe Int)
counter (write, prevread) i = ((write', prevread'), output)
  where
    output    = if write then Just (succ prevread) else Nothing
    prevread' = if write then prevread else i
    write' = not write

-- | Write on odd cyles
f :: Clock System Source
  -> Reset System Asynchronous
  -> BiSignalIn  Undefined System (BitSize Int)
  -> BiSignalOut Undefined System (BitSize Int)
f clk rst s = writeToBiSignal s (mealy clk rst counter (False, 0) (readFromBiSignal s))

-- | Write on even cyles
g :: Clock System Source
  -> Reset System Asynchronous
  -> BiSignalIn  Undefined System (BitSize Int)
  -> BiSignalOut Undefined System (BitSize Int)
g clk rst s = writeToBiSignal s (mealy clk rst counter (True, 0) (readFromBiSignal s))


-- | Connect the /f/ and /g/ circuits to the same bus
topEntity :: Clock System Source
          -> Reset System Asynchronous
          -> Signal System Int
topEntity clk rst = readFromBiSignal bus'
  where
    bus  = mergeBiSignalOuts $ f clk rst bus' :> g clk rst bus' :> Nil
    bus' = veryUnsafeToBiSignalIn bus
```