### PR TITLE
Fix Read instances for Sized number types

### DIFF
--- a/src/Clash/Sized/Internal/Index.hs
+++ b/src/Clash/Sized/Internal/Index.hs
@@ -78,6 +78,7 @@ import Data.Proxy                 (Proxy (..))
 import Text.Read                  (Read (..), ReadPrec)
 import Language.Haskell.TH        (TypeQ, appT, conT, litT, numTyLit, sigE)
 import Language.Haskell.TH.Syntax (Lift(..))
+import Numeric.Natural            (Natural)
 import GHC.TypeLits               (CmpNat, KnownNat, Nat, type (+), type (-),
                                    type (*), type (<=), natVal)
 import GHC.TypeLits.Extra         (CLog)
@@ -362,7 +363,7 @@ instance ShowX (Index n) where
 
 -- | None of the 'Read' class' methods are synthesisable.
 instance KnownNat n => Read (Index n) where
-  readPrec = fromIntegral <$> (readPrec :: ReadPrec Word)
+  readPrec = fromIntegral <$> (readPrec :: ReadPrec Natural)
 
 instance KnownNat n => Default (Index n) where
   def = fromInteger# 0

--- a/src/Clash/Sized/Internal/Signed.hs
+++ b/src/Clash/Sized/Internal/Signed.hs
@@ -169,7 +169,7 @@ instance ShowX (Signed n) where
 
 -- | None of the 'Read' class' methods are synthesisable.
 instance KnownNat n => Read (Signed n) where
-  readPrec = fromIntegral <$> (readPrec :: ReadPrec Int)
+  readPrec = fromIntegral <$> (readPrec :: ReadPrec Integer)
 
 instance KnownNat n => BitPack (Signed n) where
   type BitSize (Signed n) = n

--- a/src/Clash/Sized/Internal/Unsigned.hs
+++ b/src/Clash/Sized/Internal/Unsigned.hs
@@ -87,6 +87,7 @@ import GHC.TypeLits                   (KnownNat, Nat, type (+), natVal)
 import GHC.TypeLits.Extra             (Max)
 import Language.Haskell.TH            (TypeQ, appT, conT, litT, numTyLit, sigE)
 import Language.Haskell.TH.Syntax     (Lift(..))
+import Numeric.Natural                (Natural)
 import Test.QuickCheck.Arbitrary      (Arbitrary (..), CoArbitrary (..),
                                        arbitraryBoundedIntegral,
                                        coarbitraryIntegral)
@@ -157,7 +158,7 @@ instance ShowX (Unsigned n) where
 
 -- | None of the 'Read' class' methods are synthesisable.
 instance KnownNat n => Read (Unsigned n) where
-  readPrec = fromIntegral <$> (readPrec :: ReadPrec Word)
+  readPrec = fromIntegral <$> (readPrec :: ReadPrec Natural)
 
 instance BitPack (Unsigned n) where
   type BitSize (Unsigned n) = n


### PR DESCRIPTION
The Read instances for `Signed`, `Unsigned`, and `Index` didn't properly
work for numbers using more than 64 bits.

Before:
```haskell
> read ("0x1" <> Prelude.replicate 16 '0') :: Unsigned 65
0
```

After:
```haskell
> read ("0x1" <> Prelude.replicate 16 '0') :: Unsigned 65
18446744073709551616
```