### PR TITLE
Custom bit-representations

### DIFF
--- a/clash-prelude.cabal
+++ b/clash-prelude.cabal
@@ -212,6 +212,7 @@ Library
                       reflection                >= 2       && < 2.2,
                       singletons                >= 1.0     && < 3.0,
                       template-haskell          >= 2.12.0.0 && < 2.15,
+                      th-orphans                >= 0.13.4  && < 0.14,
                       transformers              >= 0.4.2.0 && < 0.6,
                       vector                    >= 0.11    && < 1.0
 

--- a/clash-prelude.cabal
+++ b/clash-prelude.cabal
@@ -87,6 +87,7 @@ Library
   Exposed-modules:    Clash.Annotations.TopEntity
                       Clash.Annotations.Primitive
                       Clash.Annotations.BitRepresentation
+                      Clash.Annotations.BitRepresentation.Deriving
 
                       Clash.Class.BitPack
                       Clash.Class.Num

--- a/clash-prelude.cabal
+++ b/clash-prelude.cabal
@@ -236,6 +236,28 @@ test-suite doctests
       doctest >= 0.9.1 && < 0.17,
       clash-prelude
 
+test-suite unittests
+  type:             exitcode-stdio-1.0
+  default-language: Haskell2010
+  main-is:          unittests.hs
+  ghc-options:      -Wall
+  hs-source-dirs:   tests
+
+  if !flag(doctests)
+    buildable: False
+  else
+    build-depends:
+      clash-prelude,
+
+      base          >= 4        && < 5,
+      doctest       >= 0.9.1    && < 0.14,
+      tasty         >= 0.10.1.2 && < 0.12,
+      tasty-hunit
+
+  Other-Modules: Clash.Tests.DerivingDataRepr
+                 Clash.Tests.DerivingDataReprTrain
+
+
 benchmark benchmark-clash-prelude
   type:             exitcode-stdio-1.0
   default-language: Haskell2010

--- a/clash-prelude.cabal
+++ b/clash-prelude.cabal
@@ -86,6 +86,7 @@ Library
 
   Exposed-modules:    Clash.Annotations.TopEntity
                       Clash.Annotations.Primitive
+                      Clash.Annotations.BitRepresentation
 
                       Clash.Class.BitPack
                       Clash.Class.Num

--- a/clash-prelude.cabal
+++ b/clash-prelude.cabal
@@ -217,6 +217,7 @@ Library
                       singletons                >= 1.0     && < 3.0,
                       template-haskell          >= 2.12.0.0 && < 2.15,
                       th-lift                   >= 0.7.0    && < 0.8.0,
+                      th-orphans                >= 0.13.6   && < 1.0,
                       text                      >= 0.11.3.1 && < 1.3,
                       transformers              >= 0.4.2.0 && < 0.6,
                       vector                    >= 0.11    && < 1.0

--- a/clash-prelude.cabal
+++ b/clash-prelude.cabal
@@ -250,8 +250,8 @@ test-suite unittests
       clash-prelude,
 
       base          >= 4        && < 5,
-      doctest       >= 0.9.1    && < 0.14,
-      tasty         >= 0.10.1.2 && < 0.12,
+      doctest       >= 0.9.1    && < 0.16,
+      tasty         >= 0.10.1.2 && < 2.0,
       tasty-hunit
 
   Other-Modules: Clash.Tests.DerivingDataRepr

--- a/clash-prelude.cabal
+++ b/clash-prelude.cabal
@@ -255,7 +255,7 @@ test-suite unittests
       tasty-hunit
 
   Other-Modules: Clash.Tests.DerivingDataRepr
-                 Clash.Tests.DerivingDataReprTrain
+                 Clash.Tests.DerivingDataReprTypes
 
 
 benchmark benchmark-clash-prelude

--- a/clash-prelude.cabal
+++ b/clash-prelude.cabal
@@ -88,6 +88,7 @@ Library
                       Clash.Annotations.Primitive
                       Clash.Annotations.BitRepresentation
                       Clash.Annotations.BitRepresentation.Deriving
+                      Clash.Annotations.BitRepresentation.Internal
                       Clash.Annotations.BitRepresentation.Util
 
                       Clash.Class.BitPack

--- a/clash-prelude.cabal
+++ b/clash-prelude.cabal
@@ -88,6 +88,7 @@ Library
                       Clash.Annotations.Primitive
                       Clash.Annotations.BitRepresentation
                       Clash.Annotations.BitRepresentation.Deriving
+                      Clash.Annotations.BitRepresentation.Util
 
                       Clash.Class.BitPack
                       Clash.Class.Num
@@ -207,13 +208,15 @@ Library
                       ghc-typelits-extra        >= 0.2.5   && < 0.3,
                       ghc-typelits-knownnat     >= 0.5     && < 0.6,
                       ghc-typelits-natnormalise >= 0.6     && < 0.7,
+                      hashable                  >= 1.2.1.0  && < 1.3,
                       half                      >= 0.2.2.3 && < 1.0,
                       lens                      >= 4.9     && < 4.18,
                       QuickCheck                >= 2.7     && < 2.12,
                       reflection                >= 2       && < 2.2,
                       singletons                >= 1.0     && < 3.0,
                       template-haskell          >= 2.12.0.0 && < 2.15,
-                      th-orphans                >= 0.13.4  && < 0.14,
+                      th-lift                   >= 0.7.0    && < 0.8.0,
+                      text                      >= 0.11.3.1 && < 1.3,
                       transformers              >= 0.4.2.0 && < 0.6,
                       vector                    >= 0.11    && < 1.0
 

--- a/src/Clash/Annotations/BitRepresentation.hs
+++ b/src/Clash/Annotations/BitRepresentation.hs
@@ -1,0 +1,54 @@
+{-|
+Copyright  :  (C) 2017, Google Inc.
+License    :  BSD2 (see the file LICENSE)
+Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
+
+This module houses annotations allowing custom bit representations for (custom)
+data types.
+-}
+
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE RankNTypes #-}
+
+module Clash.Annotations.BitRepresentation
+ ( DataRepr(..)
+ , ConstrRepr(..)
+ ) where
+
+import qualified Language.Haskell.TH.Syntax as TH
+
+import Data.Data (Data)
+import Data.Typeable (Typeable)
+
+type BitMask  = Word
+type Value    = Word
+type Size     = Word
+
+type FieldAnn = BitMask
+
+-- | Type annotation (Data)
+data DataRepr a =
+  DataRepr
+    Size
+    -- ^ Size of type
+    [ConstrRepr]
+    -- ^ Constructors
+      deriving (Data, Typeable)
+
+-- | Constructor annotation.
+data ConstrRepr =
+  ConstrRepr
+    TH.Name
+    -- ^ Constructor name
+    BitMask
+    -- ^ Bits relevant for this constructor
+    Value
+    -- ^ data & mask should be equal to..
+    [FieldAnn]
+    -- ^ Masks for fields. Indicates where fields are stored.
+      deriving (Data, Typeable)
+
+

--- a/src/Clash/Annotations/BitRepresentation.hs
+++ b/src/Clash/Annotations/BitRepresentation.hs
@@ -19,34 +19,25 @@ bit-representation for a data type. See @DataReprAnn@ for documentation.
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Clash.Annotations.BitRepresentation
- ( DataRepr'(..)
- , ConstrRepr'(..)
- , DataReprAnn(..)
+ (
+ -- * Data structures to express a custom bit representation
+   DataReprAnn(..)
  , ConstrRepr(..)
- , CustomReprs
- , Type'(..)
+ -- * Convenience type synonyms for Integer
  , BitMask
  , Value
  , Size
+ , FieldAnn
+
+ -- * Functions
  , reprType
- , buildCustomReprs
- , dataReprAnnToDataRepr'
- , getConstrRepr
- , getDataRepr
- , thTypeToType'
  ) where
 
-import           Control.DeepSeq            (NFData)
 import           Data.Data                  (Data)
-import           Data.Hashable              (Hashable)
-import qualified Data.Map                   as Map
-import qualified Data.Text.Lazy             as Text
 import           Data.Typeable              (Typeable)
 import qualified Language.Haskell.TH.Lib    as TH
 import qualified Language.Haskell.TH.Lift   ()
 import qualified Language.Haskell.TH.Syntax as TH
-import           GHC.Generics               (Generic)
-
 
 type BitMask  = Integer
 type Value    = Integer
@@ -139,86 +130,3 @@ data ConstrRepr =
     -- Masks for fields. Indicates where fields are stored:
     [FieldAnn]
       deriving (Show, Data, Typeable)
-
-
--- | Simple version of template haskell type. Used to
-data Type'
-  = AppTy' Type' Type'
-  -- ^ Type application
-  | ConstTy' Text.Text
-  -- ^ Qualified name of type
-  | LitTy' Integer
-  -- ^ Numeral literal (used in BitVector 10, for example)
-    deriving (Generic, NFData, Eq, Typeable, Hashable, Ord, Show)
-
--- | Internal version of DataRepr
-data DataRepr' =
-  DataRepr'
-    -- Qualified name of type (recursive):
-    Type'
-    -- Size of data type:
-    Size
-    -- Constructors:
-    [ConstrRepr']
-      deriving (Show, Generic, NFData, Eq, Typeable, Hashable, Ord)
-
--- | Internal version of ConstRepr
-data ConstrRepr' =
-  ConstrRepr'
-    -- Qualified name of constructor:
-    Text.Text
-    -- Syntactical position in the custom representations definition:
-    Int
-    -- Mask needed to determine constructor:
-    BitMask
-    -- Value after applying mask:
-    Value
-    -- Indicates where fields are stored:
-    [FieldAnn]
-      deriving (Show, Generic, NFData, Eq, Typeable, Ord, Hashable)
-
-dataReprAnnToDataRepr' :: DataReprAnn -> DataRepr'
-dataReprAnnToDataRepr' (DataReprAnn typ size constrs) =
-  DataRepr' (thTypeToType' typ) size (zipWith toConstrRepr' [0..] constrs)
-    where
-      toConstrRepr' :: Int -> ConstrRepr -> ConstrRepr'
-      toConstrRepr' n (ConstrRepr name mask value fieldanns) =
-        ConstrRepr' (thToText name) n mask value (map fromIntegral fieldanns)
-
-thToText :: TH.Name -> Text.Text
-thToText (TH.Name (TH.OccName name') (TH.NameG _namespace _pkgName (TH.ModName modName))) =
-  Text.pack $ modName ++ "." ++ name'
-thToText name' = error $ "Unexpected pattern: " ++ show name'
-
--- | Convert template haskell type to simple representation of type
-thTypeToType' :: TH.Type -> Type'
-thTypeToType' ty = go ty
-  where
-    go (TH.ConT name')   = ConstTy' (thToText name')
-    go (TH.AppT ty1 ty2) = AppTy' (go ty1) (go ty2)
-    go (TH.LitT (TH.NumTyLit n)) = LitTy' n
-    go _ = error $ "Unsupported type: " ++ show ty
-
--- | Convenience type for index built by buildCustomReprs
-type CustomReprs =
-  ( Map.Map Type' DataRepr'
-  , Map.Map Text.Text ConstrRepr'
-  )
-
--- | Lookup data type representation based on name
-getDataRepr :: Type' -> CustomReprs -> Maybe DataRepr'
-getDataRepr name (reprs, _) = Map.lookup name reprs
-
--- | Lookup constructor representation based on name
-getConstrRepr :: Text.Text -> CustomReprs -> Maybe ConstrRepr'
-getConstrRepr name (_, reprs) = Map.lookup name reprs
-
--- | Add CustomRepr to existing index
-buildCustomRepr :: CustomReprs -> DataRepr' -> CustomReprs
-buildCustomRepr (dMap, cMap) d@(DataRepr' name _size constrReprs) =
-  let insertConstr c@(ConstrRepr' name' _ _ _ _) cMap' = Map.insert name' c cMap' in
-  (Map.insert name d dMap, foldr insertConstr cMap constrReprs)
-
--- | Create indices based on names of constructors and data types
-buildCustomReprs :: [DataRepr'] -> CustomReprs
-buildCustomReprs = foldl buildCustomRepr (Map.empty, Map.empty)

--- a/src/Clash/Annotations/BitRepresentation.hs
+++ b/src/Clash/Annotations/BitRepresentation.hs
@@ -115,7 +115,7 @@ data DataReprAnn =
     Size
     -- Constructors:
     [ConstrRepr]
-      deriving (Show, Data, Typeable)
+      deriving (Show, Data, Typeable, Eq)
 
 -- | Annotation for constructors. Indicates how to match this constructor based
 -- off of the whole datatype.
@@ -129,4 +129,4 @@ data ConstrRepr =
     Value
     -- Masks for fields. Indicates where fields are stored:
     [FieldAnn]
-      deriving (Show, Data, Typeable)
+      deriving (Show, Data, Typeable, Eq)

--- a/src/Clash/Annotations/BitRepresentation.hs
+++ b/src/Clash/Annotations/BitRepresentation.hs
@@ -25,9 +25,9 @@ import qualified Language.Haskell.TH.Syntax as TH
 import Data.Data (Data)
 import Data.Typeable (Typeable)
 
-type BitMask  = Word
-type Value    = Word
-type Size     = Word
+type BitMask  = Integer
+type Value    = Integer
+type Size     = Integer
 
 type FieldAnn = BitMask
 
@@ -99,5 +99,3 @@ data ConstrRepr =
     [FieldAnn]
     -- ^ Masks for fields. Indicates where fields are stored.
       deriving (Show, Data, Typeable)
-
-

--- a/src/Clash/Annotations/BitRepresentation.hs
+++ b/src/Clash/Annotations/BitRepresentation.hs
@@ -41,7 +41,7 @@ import qualified Language.Haskell.TH.Syntax as TH
 
 type BitMask  = Integer
 type Value    = Integer
-type Size     = Integer
+type Size     = Int
 
 type FieldAnn = BitMask
 

--- a/src/Clash/Annotations/BitRepresentation.hs
+++ b/src/Clash/Annotations/BitRepresentation.hs
@@ -11,7 +11,6 @@ data types.
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE RankNTypes #-}
 
 module Clash.Annotations.BitRepresentation
@@ -21,7 +20,6 @@ module Clash.Annotations.BitRepresentation
  , TypeName(..)
  ) where
 
-import Language.Haskell.TH.Instances ()           -- instance Lift TH.Name
 import qualified Language.Haskell.TH.Syntax as TH
 
 import Data.Data (Data)
@@ -37,7 +35,7 @@ data TypeName = TN TH.Name [TypeName]
               -- ^ Type name with a number of types as arguments
               | TT TH.Name
               -- ^ Type name terminal; equivalent to TN with an empty list
-                 deriving (Show, Data, Typeable, TH.Lift)
+                 deriving (Show, Data, Typeable)
 
 -- | Type annotation for inline annotations. Example usage:
 --

--- a/src/Clash/Annotations/BitRepresentation.hs
+++ b/src/Clash/Annotations/BitRepresentation.hs
@@ -17,8 +17,7 @@ data types.
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Clash.Annotations.BitRepresentation
- ( DataRepr(..)
- , DataRepr'(..)
+ ( DataRepr'(..)
  , ConstrRepr'(..)
  , DataReprAnn(..)
  , ConstrRepr(..)
@@ -99,31 +98,7 @@ data DataReprAnn =
     -- ^ Constructors
       deriving (Show, Data, Typeable)
 
--- | Type annotation for annotations specified in a separate file, interpreted
--- by Clash using '-fclash-custom-reprs <path>'.
---
--- @
--- data Color = R | G | B
--- colorAnn = DataRepr 2 [...] :: DataRepr Color
--- @
---
--- To annotate composed types, simply extend /colorAnn/s type. For example, if
--- we want to annotate `Maybe Color`:
---
--- @
--- data Color = R | G | B
--- colorAnn = DataRepr 2 [...] :: DataRepr (Maybe Color)
--- @
 
-data DataRepr a =
-  DataRepr
-    Size
-    -- ^ Size of type
-    [ConstrRepr]
-    -- ^ Constructors
-      deriving (Show, Data, Typeable)
-
--- | Constructor annotation.
 data ConstrRepr =
   ConstrRepr
     TH.Name

--- a/src/Clash/Annotations/BitRepresentation.hs
+++ b/src/Clash/Annotations/BitRepresentation.hs
@@ -11,6 +11,7 @@ data types.
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE RankNTypes #-}
 
 module Clash.Annotations.BitRepresentation
@@ -20,6 +21,7 @@ module Clash.Annotations.BitRepresentation
  , TypeName(..)
  ) where
 
+import Language.Haskell.TH.Instances ()           -- instance Lift TH.Name
 import qualified Language.Haskell.TH.Syntax as TH
 
 import Data.Data (Data)
@@ -35,7 +37,7 @@ data TypeName = TN TH.Name [TypeName]
               -- ^ Type name with a number of types as arguments
               | TT TH.Name
               -- ^ Type name terminal; equivalent to TN with an empty list
-                 deriving (Show, Data, Typeable)
+                 deriving (Show, Data, Typeable, TH.Lift)
 
 -- | Type annotation for inline annotations. Example usage:
 --

--- a/src/Clash/Annotations/BitRepresentation.hs
+++ b/src/Clash/Annotations/BitRepresentation.hs
@@ -34,6 +34,7 @@ module Clash.Annotations.BitRepresentation
 
 import           Data.Data                  (Data)
 import           Data.Typeable              (Typeable)
+import           Language.Haskell.TH.Instances ()
 import qualified Language.Haskell.TH.Lift   ()
 import qualified Language.Haskell.TH.Syntax as TH
 import           GHC.Generics               (Generic)
@@ -47,10 +48,6 @@ type FieldAnn = BitMask
 -- | Lift values inside of 'TH.Q' to a Template Haskell expression
 liftQ :: TH.Lift a => TH.Q a -> TH.Q TH.Exp
 liftQ = (>>= TH.lift)
-
-deriving instance TH.Lift TH.Type
-deriving instance TH.Lift TH.TyVarBndr
-deriving instance TH.Lift TH.TyLit
 
 -- NOTE: The following instances are imported from Language.Haskell.TH.Lift.
 -- This module also implements 'instance Lift Exp', which might make debugging

--- a/src/Clash/Annotations/BitRepresentation.hs
+++ b/src/Clash/Annotations/BitRepresentation.hs
@@ -18,16 +18,33 @@ data types.
 
 module Clash.Annotations.BitRepresentation
  ( DataRepr(..)
+ , DataRepr'(..)
+ , ConstrRepr'(..)
  , DataReprAnn(..)
  , ConstrRepr(..)
+ , CustomReprs
+ , Type'(..)
+ , BitMask
+ , Value
+ , Size
  , reprType
+ , buildCustomReprs
+ , dataReprAnnToDataRepr'
+ , getConstrRepr
+ , getDataRepr
  ) where
 
+import GHC.Generics (Generic)
+import Control.DeepSeq (NFData)
+import Data.Typeable (Typeable)
+import Data.Hashable (Hashable)
+import Data.Data (Data)
+
+import qualified Data.Map as Map
+import qualified Data.Text.Lazy as Text
 import qualified Language.Haskell.TH.Lib as TH
 import qualified Language.Haskell.TH.Syntax as TH
-
-import Data.Data (Data)
-import Data.Typeable (Typeable)
+import qualified Language.Haskell.TH.Lift ()
 
 type BitMask  = Integer
 type Value    = Integer
@@ -39,25 +56,27 @@ reprType :: TH.TypeQ -> TH.ExpQ
 reprType qty = qty >>= TH.lift
 
 deriving instance TH.Lift TH.Type
-
--- NOTE: Don't import these from Language.Haskell.TH.Instances
---       Doing so will also import `instance Lift Exp`
---       And that changes certain TH mistakes from compile to run time errors.
 deriving instance TH.Lift TH.TyVarBndr
 deriving instance TH.Lift TH.TyLit
-deriving instance TH.Lift TH.Name
-deriving instance TH.Lift TH.OccName
-deriving instance TH.Lift TH.NameFlavour
-deriving instance TH.Lift TH.ModName
-deriving instance TH.Lift TH.NameSpace
-deriving instance TH.Lift TH.PkgName
+
+-- NOTE: The following instances are imported from Language.Haskell.TH.Instances.
+-- This module also implements 'instance Lift Exp', which might make debugging
+-- template haskell more difficult. Please uncomment these instnaces and the
+-- import of TH.Instances whenever it suits you.
+--
+--deriving instance TH.Lift TH.Name
+--deriving instance TH.Lift TH.OccName
+--deriving instance TH.Lift TH.NameFlavour
+--deriving instance TH.Lift TH.ModName
+--deriving instance TH.Lift TH.NameSpace
+--deriving instance TH.Lift TH.PkgName
 
 
 -- | Type annotation for inline annotations. Example usage:
 --
 -- @
 -- data Color = R | G | B
--- {-# ANN module (DataReprAnn $(typeOf [t|Color|]) 2 [...]) #-}
+-- {-# ANN module (DataReprAnn $(reprType [t|Color|]) 2 [...]) #-}
 -- @
 --
 -- Or if we want to annotate
@@ -65,7 +84,7 @@ deriving instance TH.Lift TH.PkgName
 --
 -- @
 -- {-# ANN module ( DataReprAnn
---                    $(typeOf [t|Maybe Color|])
+--                    $(reprType [t|Maybe Color|])
 --                    2
 --                    [...] ) #-}
 -- @
@@ -115,3 +134,76 @@ data ConstrRepr =
     [FieldAnn]
     -- ^ Masks for fields. Indicates where fields are stored.
       deriving (Show, Data, Typeable)
+
+
+-- |
+data Type' = AppTy' Type' Type'
+           | ConstTy' Text.Text
+           | LitTy' Integer
+    deriving (Generic, NFData, Eq, Typeable, Hashable, Ord, Show)
+
+-- |
+data DataRepr' =
+  DataRepr'
+    Type'
+    -- ^ Qualified name of type (recursive)
+    Size
+    -- ^ Size of data type
+    [ConstrRepr']
+    -- ^ Constructors
+      deriving (Show, Generic, NFData, Eq, Typeable, Hashable, Ord)
+
+-- |
+data ConstrRepr' =
+  ConstrRepr'
+    Text.Text
+    -- ^ Qualified name of constructor
+    Int
+    -- ^ Syntactical position in the custom representations definition.
+    BitMask
+    -- ^ Mask needed to determine constructor
+    Value
+    -- ^ Value after applying mask
+    [FieldAnn]
+    --
+      deriving (Show, Generic, NFData, Eq, Typeable, Ord, Hashable)
+
+dataReprAnnToDataRepr' :: DataReprAnn -> DataRepr'
+dataReprAnnToDataRepr' (DataReprAnn typ size constrs) =
+  DataRepr' (toType' typ) size (zipWith toConstrRepr' [0..] constrs)
+    where
+      toConstrRepr' :: Int -> ConstrRepr -> ConstrRepr'
+      toConstrRepr' n (ConstrRepr name mask value fieldanns) =
+        ConstrRepr' (thToText name) n (fromIntegral mask) value (map fromIntegral fieldanns)
+
+      thToText :: TH.Name -> Text.Text
+      thToText (TH.Name (TH.OccName name') (TH.NameG _namespace _pkgName (TH.ModName modName))) =
+        Text.pack $ modName ++ "." ++ name'
+      thToText name' = error $ {-$(curLoc) ++-} "Unexpected pattern: " ++ show name'
+
+      toType' :: TH.Type -> Type'
+      toType' ty = go ty
+        where
+          go (TH.ConT name')   = ConstTy' (thToText name')
+          go (TH.AppT ty1 ty2) = AppTy' (go ty1) (go ty2)
+          go (TH.LitT (TH.NumTyLit n)) = LitTy' n
+          go _ = error $ {-$(curLoc) ++-} "Unsupported type: " ++ show ty
+
+
+type CustomReprs = ( Map.Map Type' DataRepr'
+                   , Map.Map Text.Text ConstrRepr'
+                   )
+
+getDataRepr :: Type' -> CustomReprs -> Maybe DataRepr'
+getDataRepr name (reprs, _) = Map.lookup name reprs
+
+getConstrRepr :: Text.Text -> CustomReprs -> Maybe ConstrRepr'
+getConstrRepr name (_, reprs) = Map.lookup name reprs
+
+buildCustomRepr :: DataRepr' -> CustomReprs -> CustomReprs
+buildCustomRepr d@(DataRepr' name _size constrReprs) (dMap, cMap) =
+  let insertConstr c@(ConstrRepr' name' _ _ _ _) cMap' = Map.insert name' c cMap' in
+  (Map.insert name d dMap, foldr insertConstr cMap constrReprs)
+
+buildCustomReprs :: [DataRepr'] -> CustomReprs
+buildCustomReprs = foldr buildCustomRepr (Map.empty, Map.empty)

--- a/src/Clash/Annotations/BitRepresentation.hs
+++ b/src/Clash/Annotations/BitRepresentation.hs
@@ -1,19 +1,21 @@
 {-|
-Copyright  :  (C) 2017, Google Inc.
+Copyright  :  (C) 2018, Google Inc.
 License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 
-This module houses annotations allowing custom bit representations for (custom)
-data types.
+Using /ANN/ pragma's you can tell the Clash compiler to use a custom
+bit-representation for a data type. See @DataReprAnn@ for documentation.
+
 -}
 
-{-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveAnyClass     #-}
 {-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE DeriveLift #-}
+{-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE DeriveLift         #-}
+{-# LANGUAGE RankNTypes         #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TemplateHaskell    #-}
+
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Clash.Annotations.BitRepresentation
@@ -34,17 +36,17 @@ module Clash.Annotations.BitRepresentation
  , thTypeToType'
  ) where
 
-import GHC.Generics (Generic)
-import Control.DeepSeq (NFData)
-import Data.Typeable (Typeable)
-import Data.Hashable (Hashable)
-import Data.Data (Data)
-
-import qualified Data.Map as Map
-import qualified Data.Text.Lazy as Text
-import qualified Language.Haskell.TH.Lib as TH
+import           Control.DeepSeq            (NFData)
+import           Data.Data                  (Data)
+import           Data.Hashable              (Hashable)
+import qualified Data.Map                   as Map
+import qualified Data.Text.Lazy             as Text
+import           Data.Typeable              (Typeable)
+import qualified Language.Haskell.TH.Lib    as TH
+import qualified Language.Haskell.TH.Lift   ()
 import qualified Language.Haskell.TH.Syntax as TH
-import qualified Language.Haskell.TH.Lift ()
+import           GHC.Generics               (Generic)
+
 
 type BitMask  = Integer
 type Value    = Integer
@@ -59,10 +61,10 @@ deriving instance TH.Lift TH.Type
 deriving instance TH.Lift TH.TyVarBndr
 deriving instance TH.Lift TH.TyLit
 
--- NOTE: The following instances are imported from Language.Haskell.TH.Instances.
+-- NOTE: The following instances are imported from Language.Haskell.TH.Lift.
 -- This module also implements 'instance Lift Exp', which might make debugging
--- template haskell more difficult. Please uncomment these instnaces and the
--- import of TH.Instances whenever it suits you.
+-- template haskell more difficult. Please uncomment these instances and the
+-- import of TH.Lift whenever it suits you.
 --
 --deriving instance TH.Lift TH.Name
 --deriving instance TH.Lift TH.OccName
@@ -72,76 +74,107 @@ deriving instance TH.Lift TH.TyLit
 --deriving instance TH.Lift TH.PkgName
 
 
--- | Type annotation for inline annotations. Example usage:
+-- | Annotation for custom bit representations of data types
+--
+-- Using /ANN/ pragma's you can tell the Clash compiler to use a custom
+-- bit-representation for a data type.
+--
+-- For example:
 --
 -- @
 -- data Color = R | G | B
--- {-# ANN module (DataReprAnn $(reprType [t|Color|]) 2 [...]) #-}
+-- {-# ANN module (DataReprAnn
+--                   $(reprType [t|Color|])
+--                   2
+--                   [ ConstrRepr 'R 0b11 0b00 []
+--                   , ConstrRepr 'G 0b11 0b01 []
+--                   , ConstrRepr 'B 0b11 0b10 []
+--                   ]) #-}
 -- @
 --
--- Or if we want to annotate
--- `Maybe Color`:
+-- This specifies that @R@ should be encoded as 0b00, @G@ as 0b01, and
+-- @B@ as 0b10. The first binary value in every @ConstRepr@ in this example
+-- is a mask, indicating which bits in the data type are relevant. In this case
+-- all of the bits are.
+--
+-- Or if we want to annotate @Maybe Color@:
 --
 -- @
 -- {-# ANN module ( DataReprAnn
 --                    $(reprType [t|Maybe Color|])
 --                    2
---                    [...] ) #-}
+--                    [ ConstRepr 'Nothing 0b11 0b11 []
+--                    , ConstRepr 'Just 0b00 0b00 [0b11]
+--                    ] ) #-}
 -- @
+--
+-- By default, @Maybe Color@ is a data type which consumes 3 bits. A single bit
+-- to indicate the constructor (either @Just@ or @Nothing@), and two bits to encode
+-- the first field of @Just@. Notice that we saved a single bit, by exploiting
+-- the fact that @Color@ only uses three values (0, 1, 2), but takes two bits
+-- to encode it. We can therefore use the last - unused - value (3), to encode
+-- one of the constructors of @Maybe@. We indicate which bits encode the
+-- underlying @Color@ by passing /[0b11]/ to ConstRepr. This indicates that the
+-- first field is encoded in the first and second bit of the whole datatype (0b11).
 data DataReprAnn =
   DataReprAnn
+    -- Type this annotation is for:
     TH.Type
-    -- ^ Type this annotation is for
+    -- Size of type:
     Size
-    -- ^ Size of type
+    -- Constructors:
     [ConstrRepr]
-    -- ^ Constructors
       deriving (Show, Data, Typeable)
 
-
+-- | Annotation for constructors. Indicates how to match this constructor based
+-- off of the whole datatype.
 data ConstrRepr =
   ConstrRepr
+    -- Constructor name:
     TH.Name
-    -- ^ Constructor name
+    -- Bits relevant for this constructor:
     BitMask
-    -- ^ Bits relevant for this constructor
+    -- data & mask should be equal to..:
     Value
-    -- ^ data & mask should be equal to..
+    -- Masks for fields. Indicates where fields are stored:
     [FieldAnn]
-    -- ^ Masks for fields. Indicates where fields are stored.
       deriving (Show, Data, Typeable)
 
 
--- |
-data Type' = AppTy' Type' Type'
-           | ConstTy' Text.Text
-           | LitTy' Integer
+-- | Simple version of template haskell type. Used to
+data Type'
+  = AppTy' Type' Type'
+  -- ^ Type application
+  | ConstTy' Text.Text
+  -- ^ Qualified name of type
+  | LitTy' Integer
+  -- ^ Numeral literal (used in BitVector 10, for example)
     deriving (Generic, NFData, Eq, Typeable, Hashable, Ord, Show)
 
--- |
+-- | Internal version of DataRepr
 data DataRepr' =
   DataRepr'
+    -- Qualified name of type (recursive):
     Type'
-    -- ^ Qualified name of type (recursive)
+    -- Size of data type:
     Size
-    -- ^ Size of data type
+    -- Constructors:
     [ConstrRepr']
-    -- ^ Constructors
       deriving (Show, Generic, NFData, Eq, Typeable, Hashable, Ord)
 
--- |
+-- | Internal version of ConstRepr
 data ConstrRepr' =
   ConstrRepr'
+    -- Qualified name of constructor:
     Text.Text
-    -- ^ Qualified name of constructor
+    -- Syntactical position in the custom representations definition:
     Int
-    -- ^ Syntactical position in the custom representations definition.
+    -- Mask needed to determine constructor:
     BitMask
-    -- ^ Mask needed to determine constructor
+    -- Value after applying mask:
     Value
-    -- ^ Value after applying mask
+    -- Indicates where fields are stored:
     [FieldAnn]
-    --
       deriving (Show, Generic, NFData, Eq, Typeable, Ord, Hashable)
 
 dataReprAnnToDataRepr' :: DataReprAnn -> DataRepr'
@@ -155,30 +188,37 @@ dataReprAnnToDataRepr' (DataReprAnn typ size constrs) =
 thToText :: TH.Name -> Text.Text
 thToText (TH.Name (TH.OccName name') (TH.NameG _namespace _pkgName (TH.ModName modName))) =
   Text.pack $ modName ++ "." ++ name'
-thToText name' = error $ {-$(curLoc) ++-} "Unexpected pattern: " ++ show name'
+thToText name' = error $ "Unexpected pattern: " ++ show name'
 
+-- | Convert template haskell type to simple representation of type
 thTypeToType' :: TH.Type -> Type'
 thTypeToType' ty = go ty
   where
     go (TH.ConT name')   = ConstTy' (thToText name')
     go (TH.AppT ty1 ty2) = AppTy' (go ty1) (go ty2)
     go (TH.LitT (TH.NumTyLit n)) = LitTy' n
-    go _ = error $ {-$(curLoc) ++-} "Unsupported type: " ++ show ty
+    go _ = error $ "Unsupported type: " ++ show ty
 
-type CustomReprs = ( Map.Map Type' DataRepr'
-                   , Map.Map Text.Text ConstrRepr'
-                   )
+-- | Convenience type for index built by buildCustomReprs
+type CustomReprs =
+  ( Map.Map Type' DataRepr'
+  , Map.Map Text.Text ConstrRepr'
+  )
 
+-- | Lookup data type representation based on name
 getDataRepr :: Type' -> CustomReprs -> Maybe DataRepr'
 getDataRepr name (reprs, _) = Map.lookup name reprs
 
+-- | Lookup constructor representation based on name
 getConstrRepr :: Text.Text -> CustomReprs -> Maybe ConstrRepr'
 getConstrRepr name (_, reprs) = Map.lookup name reprs
 
-buildCustomRepr :: DataRepr' -> CustomReprs -> CustomReprs
-buildCustomRepr d@(DataRepr' name _size constrReprs) (dMap, cMap) =
+-- | Add CustomRepr to existing index
+buildCustomRepr :: CustomReprs -> DataRepr' -> CustomReprs
+buildCustomRepr (dMap, cMap) d@(DataRepr' name _size constrReprs) =
   let insertConstr c@(ConstrRepr' name' _ _ _ _) cMap' = Map.insert name' c cMap' in
   (Map.insert name d dMap, foldr insertConstr cMap constrReprs)
 
+-- | Create indices based on names of constructors and data types
 buildCustomReprs :: [DataRepr'] -> CustomReprs
-buildCustomReprs = foldr buildCustomRepr (Map.empty, Map.empty)
+buildCustomReprs = foldl buildCustomRepr (Map.empty, Map.empty)

--- a/src/Clash/Annotations/BitRepresentation.hs
+++ b/src/Clash/Annotations/BitRepresentation.hs
@@ -38,6 +38,7 @@ import           Data.Typeable              (Typeable)
 import qualified Language.Haskell.TH.Lib    as TH
 import qualified Language.Haskell.TH.Lift   ()
 import qualified Language.Haskell.TH.Syntax as TH
+import           GHC.Generics               (Generic)
 
 type BitMask  = Integer
 type Value    = Integer
@@ -115,7 +116,7 @@ data DataReprAnn =
     Size
     -- Constructors:
     [ConstrRepr]
-      deriving (Show, Data, Typeable, Eq)
+      deriving (Show, Data, Typeable, Eq, Generic, TH.Lift)
 
 -- | Annotation for constructors. Indicates how to match this constructor based
 -- off of the whole datatype.
@@ -129,4 +130,4 @@ data ConstrRepr =
     Value
     -- Masks for fields. Indicates where fields are stored:
     [FieldAnn]
-      deriving (Show, Data, Typeable, Eq)
+      deriving (Show, Data, Typeable, Eq, Generic, TH.Lift)

--- a/src/Clash/Annotations/BitRepresentation.hs
+++ b/src/Clash/Annotations/BitRepresentation.hs
@@ -12,6 +12,9 @@ data types.
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE DeriveLift #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Clash.Annotations.BitRepresentation
  ( DataRepr(..)
@@ -36,6 +39,19 @@ data TypeName = TN TH.Name [TypeName]
               | TT TH.Name
               -- ^ Type name terminal; equivalent to TN with an empty list
                  deriving (Show, Data, Typeable)
+
+deriving instance TH.Lift TypeName
+
+-- instances we need to derive Lift TypeName
+-- NOTE: Don't import these from Language.Haskell.TH.Instances
+--       Doing so will also import `instance Lift Exp`
+--       And that changes certain TH mistakes from compile to run time errors.
+deriving instance TH.Lift TH.Name
+deriving instance TH.Lift TH.OccName
+deriving instance TH.Lift TH.NameFlavour
+deriving instance TH.Lift TH.ModName
+deriving instance TH.Lift TH.NameSpace
+deriving instance TH.Lift TH.PkgName
 
 -- | Type annotation for inline annotations. Example usage:
 --

--- a/src/Clash/Annotations/BitRepresentation.hs
+++ b/src/Clash/Annotations/BitRepresentation.hs
@@ -4,11 +4,10 @@ License    :  BSD2 (see the file LICENSE)
 Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 
 Using /ANN/ pragma's you can tell the Clash compiler to use a custom
-bit-representation for a data type. See @DataReprAnn@ for documentation.
+bit representation for a data type. See @DataReprAnn@ for documentation.
 
 -}
 
-{-# LANGUAGE DeriveAnyClass     #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE DeriveLift         #-}
@@ -30,12 +29,11 @@ module Clash.Annotations.BitRepresentation
  , FieldAnn
 
  -- * Functions
- , reprType
+ , liftQ
  ) where
 
 import           Data.Data                  (Data)
 import           Data.Typeable              (Typeable)
-import qualified Language.Haskell.TH.Lib    as TH
 import qualified Language.Haskell.TH.Lift   ()
 import qualified Language.Haskell.TH.Syntax as TH
 import           GHC.Generics               (Generic)
@@ -46,8 +44,9 @@ type Size     = Int
 
 type FieldAnn = BitMask
 
-reprType :: TH.TypeQ -> TH.ExpQ
-reprType qty = qty >>= TH.lift
+-- | Lift values inside of 'TH.Q' to a Template Haskell expression
+liftQ :: TH.Lift a => TH.Q a -> TH.Q TH.Exp
+liftQ = (>>= TH.lift)
 
 deriving instance TH.Lift TH.Type
 deriving instance TH.Lift TH.TyVarBndr
@@ -76,7 +75,7 @@ deriving instance TH.Lift TH.TyLit
 -- @
 -- data Color = R | G | B
 -- {-# ANN module (DataReprAnn
---                   $(reprType [t|Color|])
+--                   $(liftQ [t|Color|])
 --                   2
 --                   [ ConstrRepr 'R 0b11 0b00 []
 --                   , ConstrRepr 'G 0b11 0b01 []
@@ -93,7 +92,7 @@ deriving instance TH.Lift TH.TyLit
 --
 -- @
 -- {-# ANN module ( DataReprAnn
---                    $(reprType [t|Maybe Color|])
+--                    $(liftQ [t|Maybe Color|])
 --                    2
 --                    [ ConstRepr 'Nothing 0b11 0b11 []
 --                    , ConstRepr 'Just 0b00 0b00 [0b11]

--- a/src/Clash/Annotations/BitRepresentation.hs
+++ b/src/Clash/Annotations/BitRepresentation.hs
@@ -15,7 +15,9 @@ data types.
 
 module Clash.Annotations.BitRepresentation
  ( DataRepr(..)
+ , DataReprAnn(..)
  , ConstrRepr(..)
+ , TypeName(..)
  ) where
 
 import qualified Language.Haskell.TH.Syntax as TH
@@ -29,14 +31,61 @@ type Size     = Word
 
 type FieldAnn = BitMask
 
--- | Type annotation (Data)
+data TypeName = TN TH.Name [TypeName]
+              -- ^ Type name with a number of types as arguments
+              | TT TH.Name
+              -- ^ Type name terminal; equivalent to TN with an empty list
+                 deriving (Show, Data, Typeable)
+
+-- | Type annotation for inline annotations. Example usage:
+--
+-- @
+-- data Color = R | G | B
+-- {-# ANN module (DataReprAnn (TT ''Color) 2 [...]) #-}
+-- @
+--
+-- To annotate composed types, use TN. For example, if we want to annotate
+-- `Maybe Color`:
+--
+-- @
+-- {-# ANN module ( DataReprAnn
+--                    (TN ''Maybe [TT ''Color])
+--                    2
+--                    [...] ) #-}
+-- @
+data DataReprAnn =
+  DataReprAnn
+    TypeName
+    -- ^ Type this annotation is for
+    Size
+    -- ^ Size of type
+    [ConstrRepr]
+    -- ^ Constructors
+      deriving (Show, Data, Typeable)
+
+-- | Type annotation for annotations specified in a separate file, interpreted
+-- by Clash using '-fclash-custom-reprs <path>'.
+--
+-- @
+-- data Color = R | G | B
+-- colorAnn = DataRepr 2 [...] :: DataRepr Color
+-- @
+--
+-- To annotate composed types, simply extend /colorAnn/s type. For example, if
+-- we want to annotate `Maybe Color`:
+--
+-- @
+-- data Color = R | G | B
+-- colorAnn = DataRepr 2 [...] :: DataRepr (Maybe Color)
+-- @
+
 data DataRepr a =
   DataRepr
     Size
     -- ^ Size of type
     [ConstrRepr]
     -- ^ Constructors
-      deriving (Data, Typeable)
+      deriving (Show, Data, Typeable)
 
 -- | Constructor annotation.
 data ConstrRepr =
@@ -49,6 +98,6 @@ data ConstrRepr =
     -- ^ data & mask should be equal to..
     [FieldAnn]
     -- ^ Masks for fields. Indicates where fields are stored.
-      deriving (Data, Typeable)
+      deriving (Show, Data, Typeable)
 
 

--- a/src/Clash/Annotations/BitRepresentation.hs
+++ b/src/Clash/Annotations/BitRepresentation.hs
@@ -183,7 +183,7 @@ dataReprAnnToDataRepr' (DataReprAnn typ size constrs) =
     where
       toConstrRepr' :: Int -> ConstrRepr -> ConstrRepr'
       toConstrRepr' n (ConstrRepr name mask value fieldanns) =
-        ConstrRepr' (thToText name) n (fromIntegral mask) value (map fromIntegral fieldanns)
+        ConstrRepr' (thToText name) n mask value (map fromIntegral fieldanns)
 
 thToText :: TH.Name -> Text.Text
 thToText (TH.Name (TH.OccName name') (TH.NameG _namespace _pkgName (TH.ModName modName))) =

--- a/src/Clash/Annotations/BitRepresentation/Deriving.hs
+++ b/src/Clash/Annotations/BitRepresentation/Deriving.hs
@@ -8,25 +8,43 @@
 
 module Clash.Annotations.BitRepresentation.Deriving
   ( deriveDefaultAnnotation
+  , deriveBitPack
   ) where
 
 import GHC.Exts
 import GHC.Integer.Logarithms
 
-import Data.Bits (shiftL)
+import Control.Monad (zipWithM)
+
+import Data.List (mapAccumL)
+import Data.Bits (shiftL, shiftR)
 import Data.Proxy (Proxy(..))
+import Data.Maybe (catMaybes, fromJust)
 
 import qualified Data.Map as Map
+import qualified Data.Text.Lazy as Text
 
-import Language.Haskell.TH (listE, pragAnnD)
+import Language.Haskell.TH
 import Language.Haskell.TH.Syntax
 import GHC.TypeLits (natVal)
 
-import Clash.Class.BitPack
+import Clash.Sized.BitVector (BitVector(..), high, low)
+import Clash.Class.Resize  (resize)
+import Clash.Class.BitPack (BitPack, BitSize, pack)
 import Clash.Annotations.BitRepresentation ( DataReprAnn(..)
+                                           , DataRepr'(..)
+                                           , ConstrRepr'(..)
                                            , ConstrRepr(..)
                                            , reprType
+                                           , thTypeToType'
+                                           , dataReprAnnToDataRepr'
                                            )
+
+import Clash.Annotations.BitRepresentation.Util ( bitOrigins
+                                                , BitOrigin(..)
+                                                , bitRanges
+                                                , Bit(..)
+                                                )
 
 type NameMap = Map.Map Name Type
 
@@ -172,20 +190,208 @@ deriveDataRepr typ = do
     where
       (ConT tyConstrName, typeArgs) = collectTypeArgs typ
 
--- | Derives BitPack instances for given type. Will account for custom bit
--- representation annotations in the module where the splice is ran, and all
--- modules of the types used in the data type. Note that the generated instance
--- might conflict with existing implementations (for example, an instance for
--- /Maybe a/ exists, yielding conflicts for any alternative implementations).
---
-deriveDefaultAnnotation
-  :: Q Type
+-- | Collect data reprs of current module
+collectDataReprs :: Q [DataRepr']
+collectDataReprs = do
+  thisMod <- thisModule
+  map dataReprAnnToDataRepr' <$> reifyAnnotations (AnnLookupModule thisMod)
+
+group :: [Bit] -> [(Int, Bit)]
+group [] = []
+group bs = (length head', head bs) : rest
+  where
+    tail' = dropWhile (==head bs) bs
+    head' = takeWhile (==head bs) bs
+    rest  = group tail'
+
+bitToExpr' :: (Int, Bit) -> Q Exp
+bitToExpr' (0, _) = error $ {-$(curLoc) ++-} "Unexpected group length: 0"
+bitToExpr' (1, H) = lift high
+bitToExpr' (1, L) = lift low
+bitToExpr' (1, _) = lift low
+bitToExpr' (numTyLit' -> n, H) =
+  [| complement (resize $(lift low) :: BitVector $n) |]
+bitToExpr' (numTyLit' -> n, L) =
+  [| resize $(lift low) :: BitVector $n |]
+bitToExpr' (numTyLit' -> n, _) =
+  [| resize $(lift low) :: BitVector $n |]
+
+bitsToExpr :: [Bit] -> Q Exp
+bitsToExpr [] = error $ {-$(curLoc) ++-} "Unexpected empty bit list"
+bitsToExpr bits =
+  foldl1
+    (\v1 v2 -> [| $v1 ++# $v2 |])
+    (map bitToExpr' $ group bits)
+
+numTyLit' n = LitT <$> (numTyLit $ fromIntegral n)
+
+-- | Select a list of ranges from a bitvector expression
+select'
+  :: Exp
+  -> [(Int, Int)]
+  -> Q Exp
+select' _vec [] =
+  error $ {-$(curLoc) ++ -}"Unexpected empty list of intervals"
+select' vec ranges =
+  foldl1 (\v1 v2 -> [| $v1 ++# $v2 |]) $ map (return . select'') ranges
+    where
+      select'' :: (Int, Int) -> Exp
+      select'' (from, downto) =
+        let size = from - downto + 1 in
+        let
+          shifted
+            | downto == 0 =
+                vec
+            | otherwise =
+                AppE
+                  (AppE (VarE 'shiftR) vec)
+                  (LitE $ IntegerL $ fromIntegral downto) in
+
+        SigE
+          -- Select from whole vector
+          (AppE (VarE 'resize) shifted)
+          -- Type signature:
+          (AppT (ConT ''BitVector) (LitT $ NumTyLit $ fromIntegral size))
+
+-- | Select a range (bitorigin) from a bitvector
+select
+  :: [Exp]
+  -- ^ BitVectors of fields
+  -> BitOrigin
+  -- ^ Select bits
+  -> Q Exp
+select fields (Lit []) =
+  error $ {-$(curLoc) ++-} "Unexpected empty literal."
+select fields (Lit lits) = do
+  let size = fromIntegral $ length lits
+  vec <- bitsToExpr lits
+  return $ SigE
+            -- Apply bLit to literal string
+            vec
+            -- Type signature:
+            (AppT (ConT ''BitVector) (LitT $ NumTyLit size))
+
+select fields (Field fieldn from downto) =
+  select' (fields !! fieldn) [(from, downto)]
+
+buildPackMatch
+  :: Integer
+  -> ConstrRepr'
+  -> Q Match
+buildPackMatch dataSize constrRepr@(ConstrRepr' qName constrN mask value fieldanns) = do
+  constr <- fromJust <$> lookupValueName (Text.unpack qName)
+
+  fieldNames <-
+    mapM (\n -> newName $ "field" ++ show n) [0..length fieldanns-1]
+  fieldPackedNames <-
+    mapM (\n -> newName $ "fieldPacked" ++ show n) [0..length fieldanns-1]
+
+  let packed fName = AppE (VarE 'pack) (VarE fName)
+  let pack' pName fName = ValD (VarP pName) (NormalB $ packed fName) []
+  let fieldPackedDecls = zipWith pack' fieldPackedNames fieldNames
+  let origins = bitOrigins (fromIntegral dataSize) (mask, value, fieldanns)
+
+  vec <- foldl1
+              (\v1 v2 -> [| $v1 ++# $v2 |])
+              (map (select $ map VarE fieldPackedNames) origins)
+
+  return $ Match (ConP constr (VarP <$> fieldNames)) (NormalB vec) fieldPackedDecls
+
+-- | Build a /pack/ function corresponding to given DataRepr
+buildPack
+  :: Type
+  -> DataRepr'
   -> Q [Dec]
-deriveDefaultAnnotation typQ = do
-  typ <- typQ
+buildPack argTy dataRepr@(DataRepr' _name size constrs) = do
+  argName      <- newName "toBePacked"
+  let resTy     = AppT (ConT ''BitVector) (LitT $ NumTyLit size)
+  let funcName  = mkName "pack"
+  let funcSig   = SigD funcName (AppT (AppT ArrowT argTy) resTy)
+  constrs'     <- mapM (buildPackMatch size) constrs
+  let body      = CaseE (VarE argName) constrs'
+  let func      = FunD funcName [Clause [VarP argName] (NormalB body) []]
+  return $ [funcSig, func]
 
-  typDataRepr <- deriveDataRepr typ
+buildUnpackField
+  :: Name
+  -> Integer
+  -> Q Exp
+buildUnpackField valueName mask =
+  let ranges = bitRanges mask in
+  let vec = select' (VarE valueName) ranges in
+  [| unpack $vec |]
 
-  return <$> pragAnnD ModuleAnnotation (return typDataRepr)
+buildUnpackIfE
+  :: Name
+  -> Integer
+  -> ConstrRepr'
+  -> Q (Guard, Exp)
+buildUnpackIfE valueName dataSize constrRepr@(ConstrRepr' qName constrN mask value fieldanns) = do
+  let valueName' = return $ VarE valueName
+  constr <- ConE <$> (fromJust <$> (lookupValueName (Text.unpack qName)))
+  guard  <- NormalG <$> [| ((.&.) $valueName' mask) == value |]
+  fields <- mapM (buildUnpackField valueName) fieldanns
+  return $ (guard, foldl AppE constr fields)
 
+---- | Build an /unpack/ function corresponding to given DataRepr
+buildUnpack
+  :: Type
+  -> DataRepr'
+  -> Q [Dec]
+buildUnpack resTy dataRepr@(DataRepr' _name size constrs) = do
+  argName <- newName "toBeUnpacked"
+  let funcName = mkName "unpack"
+  let argTy    = AppT (ConT ''BitVector) (LitT $ NumTyLit size)
+  let funcSig  = SigD funcName (AppT (AppT ArrowT argTy) resTy)
+  matches     <- mapM (buildUnpackIfE argName size) constrs
+  err         <- [| error $ "Could not match constructor for: " ++ show $(varE argName) |]
+  let body     = MultiIfE $ matches ++ [(NormalG (ConE 'True), err)]
+  let func     = FunD funcName [Clause [VarP argName] (NormalB body) []]
+  return $ [funcSig, func]
 
+deriveDefaultAnnotation :: Q Type -> Q [Dec]
+deriveDefaultAnnotation typ =
+  return <$> pragAnnD ModuleAnnotation (deriveDataRepr =<< typ)
+
+-- | Derives BitPack instances for given type. Will account for custom bit
+-- representation annotations in the module where the splice is ran. Note that
+-- the generated instance might conflict with existing implementations (for
+-- example, an instance for /Maybe a/ exists, yielding conflicts for any
+-- alternative implementations).
+deriveBitPack :: Q Type -> Q [Dec]
+deriveBitPack typQ = do
+  anns <- collectDataReprs
+  typ  <- typQ
+  typ' <- (return . thTypeToType') =<< typQ
+
+  let ann = case filter (\(DataRepr' t _ _) -> t == typ') anns of
+              [a] -> a
+              []  -> error $ {-$(curLoc) ++-} "No custom bit annotation found."
+              _   -> error $ {-$(curLoc) ++-} "Overlapping bit annotations found."
+
+  packFunc   <- buildPack typ ann
+  unpackFunc <- buildUnpack typ ann
+
+  let (DataRepr' _name dataSize _constrs) = ann
+
+  let bitSizeInst = TySynInstD
+                      ''BitSize
+                      (TySynEqn
+                        [typ]
+                        (LitT (NumTyLit $ fromIntegral dataSize)))
+
+  let bpInst = [ InstanceD
+                   (Just Overlapping)
+                   -- ^ Overlap
+                   []
+                   -- ^ Context
+                   (AppT (ConT ''BitPack) typ)
+                   -- ^ Type
+                   (bitSizeInst : packFunc ++ unpackFunc)
+                   -- ^ Declarations
+               ]
+  alreadyIsInstance <- isInstance ''BitPack [typ]
+  if alreadyIsInstance then
+    error $ show typ ++ " already has a BitPack instance."
+  else
+    return bpInst

--- a/src/Clash/Annotations/BitRepresentation/Deriving.hs
+++ b/src/Clash/Annotations/BitRepresentation/Deriving.hs
@@ -100,11 +100,17 @@ buildConstrRepr dataSize constrSize constrName fieldSizes constrN = [|
     constrName
     $mask
     $value
-    $(return $ ListE fieldSizes)
+    $(ListE <$> fanns)
   |]
   where
-    mask = [| bitmask ($dataSize - 1) constrSize |]
+    mask  = [| bitmask ($dataSize - 1) constrSize |]
     value = [| shiftL constrN (fromIntegral $ $dataSize - 1)|]
+    fanns =
+      sequence $ snd
+               $ mapAccumL
+                    (\start size -> ([| $start - $size |], [| bitmask $start $size |]))
+                    [| $dataSize - constrSize - 1 |]
+                    (map return fieldSizes)
 
 
 fieldTypes :: Con -> [Type]

--- a/src/Clash/Annotations/BitRepresentation/Deriving.hs
+++ b/src/Clash/Annotations/BitRepresentation/Deriving.hs
@@ -1,0 +1,354 @@
+{-# LANGUAGE DeriveLift #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE MagicHash #-}
+
+
+module Clash.Annotations.BitRepresentation.Deriving where
+
+import Prelude
+
+import Clash.Annotations.BitRepresentation
+import Clash.Class.BitPack
+
+import Data.Bits
+import Data.List (mapAccumL)
+import Data.Proxy
+
+import Language.Haskell.TH
+import Language.Haskell.TH.Syntax
+
+import GHC.Exts (Int(I#))
+import GHC.Integer.Logarithms (integerLog2#)
+
+deriveEncodingOneHot :: Q Type -> Q [Dec]
+deriveEncodingOneHot = generateModuleAnn encodingOneHot
+deriveEncodingOneHot' :: Q Type -> Q [Dec]
+deriveEncodingOneHot' = generateModuleAnn' encodingOneHot'
+
+deriveEncodingNormal :: Q Type -> Q [Dec]
+deriveEncodingNormal = generateModuleAnn encodingNormal
+
+deriveEncodingWide :: Q Type -> Q [Dec]
+deriveEncodingWide = generateModuleAnn encodingWide
+
+generateModuleAnn
+  :: (Q Type -> Q Exp)
+  -> Q Type
+  -> Q [Dec]
+generateModuleAnn derivationFunc typ
+  = do
+       let repr = derivationFunc typ
+       pragma <- pragAnnD ModuleAnnotation repr
+
+       -- we only really need the pragma, but the declaration is helpful
+       -- for debugging
+       typ' <- typ
+       nm <- newName $ "myRepr__" ++ typeToSafeName typ'
+       decl <- valD (varP nm) (normalB repr) []
+       tySig <- sigD nm [t| DataReprAnn |]
+       return [pragma, decl, tySig]
+
+generateModuleAnn'
+  :: (Q Type -> Q (Exp, [Dec]))
+  -> Q Type -> Q [Dec]
+generateModuleAnn' f q
+  = do
+       (repr,extras) <- f q
+       pragma <- pragAnnD ModuleAnnotation (return repr)
+
+       -- we only really need the pragma, but the declaration is helpful
+       -- for debugging
+       ty <- q
+       nm <- newName $ "myRepr__" ++ typeToSafeName ty
+       decl <- valD (varP nm) (normalB $ return repr) []
+       tySig <- sigD nm [t| DataReprAnn |]
+       return $ pragma : decl : tySig : extras
+
+typeToSafeName :: Type -> String
+typeToSafeName = map convertChars . show . ppr
+  where
+    convertChars c | c `elem` ". \t\n(),-" = '_'
+                   | otherwise = c
+
+encodingOneHot
+  :: Q Type
+  -> Q Exp
+encodingOneHot qty
+  = do ty <- qty
+       let tyNm = getTyNm ty
+           tyNm' = buildTypeName ty
+
+       (TyConI tyCon) <- reify tyNm
+       let
+           constructors = getCons tyCon
+           width :: Integer
+           width = fromIntegral $ length constructors
+           f :: Int -> Con -> Q Exp
+           f n con = do
+             let conNm = conName con
+                 mask = 1 `shiftL` n :: Integer
+                 value = mask
+             [| ConstrRepr conNm mask value $(listE []) |]
+
+           reps :: [Q Exp]
+           reps = zipWith f [0..] constructors
+
+       [| DataReprAnn tyNm' width $(listE reps) |]
+
+-- hack that adds BitPack instance (without functional pack/unpack, just BitSize)
+encodingOneHot'
+  :: Q Type
+  -> Q (Exp,[Dec])
+encodingOneHot' qty = do
+  ty <- qty
+  let tyNm = getTyNm ty
+      tyNm' = buildTypeName ty
+
+  (TyConI tyCon) <- reify tyNm
+  let
+      cs = getCons tyCon
+      width :: Integer
+      width = fromIntegral $ length cs
+      f :: Int -> Con -> Q Exp
+      f n con = do
+        let conNm = conName con
+            mask = 1 `shiftL` n :: Integer
+            value = mask
+        [| ConstrRepr conNm mask value $(listE []) |]
+
+      reps :: [Q Exp]
+      reps = zipWith f [0..] cs
+      body = [| DataReprAnn tyNm' width $(listE reps) |]
+
+      extra = instanceD (return []) [t| BitPack $(qty) |] [declSize,declPack,declUnpack]
+      declPack = funD 'pack [clause [] (normalB $ varE 'undefined) []] -- TODO pack implementation
+      declUnpack = funD 'unpack [clause [] (normalB $ varE 'undefined) []] -- TODO idem for unpack
+      declSize = tySynInstD ''BitSize (tySynEqn [qty] (litT $ numTyLit width))
+
+  bodyE <- body
+  extraE <- extra
+  return (bodyE, [extraE])
+
+
+encodingNormal
+  :: Q Type
+  -> Q Exp
+encodingNormal qty = do
+  ty <- qty
+  let tyNm = getTyNm ty
+      tyNm' = buildTypeName ty
+
+  (TyConI tyCon) <- reify tyNm
+  let
+    cs = getCons tyCon
+    consWidth :: Integer
+    consWidth = integerLog2Ceil $ fromIntegral $ length cs
+
+    fieldsOfConstrs = map fieldTypes cs
+
+    allWidths :: [[Q Exp]]
+    allWidths = map (map typeSize) fieldsOfConstrs
+    allWidths' :: Q [[Exp]]
+    allWidths' = sequence $ map sequence allWidths
+    allWidths'' :: Q [Exp]
+    allWidths'' = fmap (fmap ListE) allWidths'
+
+  allWidths''' <- allWidths'
+
+  let
+    allWidths2 :: Q Exp
+    allWidths2 = [| map sum $(fmap ListE allWidths'') |]
+
+    fieldBits = [| maximum $(allWidths2) |]
+
+    width :: Q Exp
+    width = [| consWidth + $(fieldBits) |]
+
+    consMask = [| let w = $(width) in maskFromDownto (w-1) (w-consWidth) |]
+
+    f :: Integer -> Con -> [Exp] -> Q Exp
+    f n con fieldWidths = do
+      let conNm = conName con
+          value = [| n `shiftL` (fromIntegral $fieldBits)|]
+      [| ConstrRepr
+           conNm
+           $consMask
+           $value
+           (fieldAnnsNormal $(width) consWidth $(return $ ListE fieldWidths))
+           |]
+
+    reps :: [Q Exp]
+    reps = zipWith3 f [0..] cs allWidths'''
+
+  [| DataReprAnn tyNm' $(width) $(listE reps) |]
+
+-- | Construct field bitmasks for normal encoding
+fieldAnnsNormal :: Integer -> Integer -> [Integer] -> [Integer]
+fieldAnnsNormal totalWidth consWidth fieldWidths = go (totalWidth-consWidth) fieldWidths
+  where
+    go n (f:fs) = maskFromDownto (n-1) (n-f) : go (n-f) fs
+    go _ [] = []
+
+
+encodingWide :: Q Type -> Q Exp
+encodingWide qty = do
+  ty <- qty
+  let tyNm = getTyNm ty
+      tyNm' = buildTypeName ty
+
+  (TyConI tyCon) <- reify tyNm
+  let
+    cs = getCons tyCon
+    consWidth :: Integer
+    consWidth = integerLog2Ceil $ fromIntegral $ length cs
+
+    fieldsOfConstrs = map fieldTypes cs
+
+    allWidths :: [[Q Exp]]
+    allWidths = map (map typeSize) fieldsOfConstrs
+    allWidths' :: Q [[Exp]]
+    allWidths' = sequence $ map sequence allWidths
+    allWidths'' :: Q [Exp]
+    allWidths'' = fmap (fmap ListE) allWidths'
+
+    allWidths2 :: Q Exp
+    allWidths2 = [| map sum $(fmap ListE allWidths'') |]
+
+    fieldBits = [| sum $allWidths2 |]
+
+    width :: Q Exp
+    width = [| consWidth + $fieldBits |]
+
+    consMask = [| let w = $width in maskFromDownto (w-1) (w-consWidth) |]
+
+    fieldMaskss :: Q Exp
+    fieldMaskss = [| fieldMasksWide $(width) consWidth $(fmap (ListE . fmap ListE) allWidths') |]
+
+    conNms = map conName cs
+    body  = [|
+      \consMaskE fieldBitsE fieldMaskssE ->
+        let reps = consRepsWide consMaskE fieldBitsE [0..] conNms fieldMaskssE in
+        DataReprAnn tyNm' $width reps
+      |]
+
+  appsE [body, consMask, fieldBits, fieldMaskss]
+
+
+consRepWide
+  :: Integer
+  -> Integer
+  -> Integer
+  -> Name
+  -> [Integer]
+  -> ConstrRepr
+consRepWide consMask fieldBits n conNm fieldMasks =
+ let value = n `shiftL` (fromIntegral fieldBits)
+ in ConstrRepr conNm consMask value fieldMasks
+
+consRepsWide
+  :: Integer
+  -> Integer
+  -> [Integer]
+  -> [Name]
+  -> [[Integer]]
+  -> [ConstrRepr]
+consRepsWide consMask fieldBits conCodes conNms fieldMasks =
+    zipWith3 (consRepWide consMask fieldBits) conCodes conNms fieldMasks
+
+
+type BitSpan = (Integer,Integer)
+type BitMask = Integer
+
+-- | Construct field bitmasks for wide encoding
+fieldMasksWide
+  :: Integer
+  -> Integer
+  -> [[Integer]]
+  -> [[Integer]]
+fieldMasksWide totalWidth consWidth fieldWidthss =
+  map (map maskSpan) $ fieldSpansWide totalWidth consWidth fieldWidthss
+
+fieldSpansWide
+  :: Integer
+  -> Integer
+  -> [[Integer]]
+  -> [[BitSpan]]
+fieldSpansWide totalWidth consWidth fieldWidthss =
+  let go a xss = snd $ mapAccumL (mapAccumL (\n w -> (n-w, (n,n-w+1)))) a xss in
+  go (totalWidth-consWidth-1) fieldWidthss
+
+typeSize :: Type -> Q Exp
+typeSize ty = [| natVal (Proxy :: Proxy (BitSize $(return ty))) |]
+
+-- | Construct bitmask from i downto j (inclusive)
+maskFromDownto :: Integer -> Integer -> BitMask
+maskFromDownto i j
+  | i < j = error $ {-$(curLoc) ++-} show i ++ " must not be smaller then " ++ show j
+  | j < 0 = error $ {-$(curLoc) ++-} "lowerbound " ++ show j ++ " is smaller than 0"
+  | otherwise = maskBits i - maskBits (j-1)
+
+maskSpan :: BitSpan -> BitMask
+maskSpan (i,j) = maskFromDownto i j
+
+-- | Construct bitmask with the n lowest bits set
+maskBits :: Integer -> BitMask
+maskBits n = (1 `shiftL` (fromIntegral $ n+1)) - 1
+
+getCons :: Dec -> [Con]
+getCons tyCon = case tyCon of
+  DataD _ _nm _tyVars _ cs _   -> cs
+  NewtypeD _ _nm _tyVars _ c _ -> [c]
+  _ -> error $ {-$(curLoc) ++-} "Can't derive encoding for a type synonym"
+
+fieldTypes :: Con -> [Type]
+fieldTypes con = case con of
+  NormalC _nm bTys -> map snd bTys
+  RecC    _nm vbTys -> map (\(_,_,ty) -> ty) vbTys
+  InfixC (_,ty1) _nm (_,ty2) -> [ty1,ty2]
+  _ -> error $ {-$(curLoc) ++-} "No support for constructors like: " ++ show con
+
+buildTypeName :: Type -> TypeName
+buildTypeName ty = case collectArgs ty of
+  Just (nm,[])   -> TT nm
+  Just (nm,args) -> TN nm (map buildTypeName args)
+  _      -> error $ {-$(curLoc) ++-} "Can't build BitRepresentation.TypeName for type: " ++ show ty
+  where
+    collectArgs :: Type -> Maybe (Name,[Type])
+    collectArgs = go []
+      where
+        go args (AppT ty1 ty2) = go (ty2:args) ty1
+        go args (ConT nm) = Just (nm,args)
+        go _    _         = Nothing
+
+conName :: Con -> Name
+conName c = case c of
+  NormalC nm _  -> nm
+  RecC    nm _  -> nm
+  InfixC _ nm _ -> nm
+  _ -> error $ {-$(curLoc) ++-} "No GADT support"
+
+getTyNm :: Type -> Name
+getTyNm ty =
+  case go ty of
+    Just t -> t
+    Nothing ->
+      error $ {-$(curLoc) ++-} unwords [ "can only handle type constants and"
+                                       , "type application, not:"
+                                       , show (ppr ty) ]
+
+  where
+    go :: Type -> Maybe Name
+    go (ConT tyNm)  = Just tyNm
+    go (AppT ty1 _) = go ty1
+    go _            = Nothing
+
+integerLog2Ceil :: Integer -> Integer
+integerLog2Ceil n =
+  let nlog2 = fromIntegral $ I# (integerLog2# n) in
+  if n > 2^nlog2 then nlog2 + 1 else nlog2
+
+
+

--- a/src/Clash/Annotations/BitRepresentation/Deriving.hs
+++ b/src/Clash/Annotations/BitRepresentation/Deriving.hs
@@ -67,7 +67,7 @@ type Derivator = Type -> Q DataReprAnnExp
 
 -- | Indicates how to pack constructor for simpleDerivator
 data ConstructorType
-  = Count
+  = Binary
   -- ^ First constructor will be encoded as 0b0, the second as 0b1, the third
   -- as 0b10, etc.
   | OneHot
@@ -308,7 +308,7 @@ simpleDerivator ctype ftype = deriveDataRepr constrDerivator fieldsDerivator
   where
     constrDerivator =
       case ctype of
-        Count -> countConstructor
+        Binary -> countConstructor
         OneHot -> oneHotConstructor
 
     fieldsDerivator =
@@ -319,7 +319,7 @@ simpleDerivator ctype ftype = deriveDataRepr constrDerivator fieldsDerivator
 -- | Derives bit representation corresponding to the default manner in which
 -- Clash stores types.
 defaultDerivator :: Derivator
-defaultDerivator = simpleDerivator Count Overlap
+defaultDerivator = simpleDerivator Binary Overlap
 
 -- | Derives bit representation corresponding to the default manner in which
 -- Clash stores types.

--- a/src/Clash/Annotations/BitRepresentation/Deriving.hs
+++ b/src/Clash/Annotations/BitRepresentation/Deriving.hs
@@ -118,11 +118,10 @@ integerLog2Ceil n =
   let nlog2 = fromIntegral $ I# (integerLog2# n) in
   if n > 2^nlog2 then nlog2 + 1 else nlog2
 
--- | Determine number of bits needed to represent /n/ options
+-- | Determine number of bits needed to represent /n/ options. Alias for
+-- integerLog2Ceil to increase readability of programmer intentention.
 bitsNeeded :: Integer -> Integer
-bitsNeeded 0 = 0
-bitsNeeded 1 = 1
-bitsNeeded n = integerLog2Ceil n
+bitsNeeded = integerLog2Ceil
 
 tyVarBndrName :: TyVarBndr -> Name
 tyVarBndrName (PlainTV n) = n
@@ -249,7 +248,7 @@ buildConstrRepr dataSize constrName fieldAnns constrMask constrValue = [|
 countConstructor :: [Integer] -> [(BitMask, Value)]
 countConstructor ns = zip (repeat mask) ns
   where
-    maskSize = integerLog2Ceil $ maximum ns
+    maskSize = bitsNeeded $ maximum ns + 1
     mask = 2^maskSize - 1
 
 oneHotConstructor :: [Integer] -> [(BitMask, Value)]
@@ -413,7 +412,7 @@ packedDataRepr typ dataWidth constrs =
     (packedConstrRepr (fromIntegral dataWidth) constrWidth 0 constrs)
   where
     external    = filter isExternal (map fst constrs)
-    constrWidth = bitsNeeded $ toInteger $ length external
+    constrWidth = bitsNeeded $ toInteger $ min (length external + 1) (length constrs)
 
 -- | Try to distribute constructor bits over fields
 storeInFields

--- a/src/Clash/Annotations/BitRepresentation/Deriving.hs
+++ b/src/Clash/Annotations/BitRepresentation/Deriving.hs
@@ -696,16 +696,16 @@ group bs = (length head', head bs) : rest
 
 bitToExpr' :: (Int, Bit) -> Q Exp
 bitToExpr' (0, _) = error $ "Unexpected group length: 0"
-bitToExpr' (1, Util.H) = lift high
-bitToExpr' (1, Util.L) = lift low
+bitToExpr' (1, Util.H) = lift (pack high)
+bitToExpr' (1, Util.L) = lift (pack low)
 -- TODO / Evaluate: Undefined bit values should not be converted
-bitToExpr' (1, _) = lift low
+bitToExpr' (1, _) = lift (pack low)
 bitToExpr' (numTyLit' -> n, Util.H) =
-  [| complement (resize $(lift low) :: BitVector $n) |]
+  [| complement (resize $(lift (pack low)) :: BitVector $n) |]
 bitToExpr' (numTyLit' -> n, Util.L) =
-  [| resize $(lift low) :: BitVector $n |]
+  [| resize $(lift (pack low)) :: BitVector $n |]
 bitToExpr' (numTyLit' -> n, _) =
-  [| resize $(lift low) :: BitVector $n |]
+  [| resize $(lift (pack low)) :: BitVector $n |]
 
 bitsToExpr :: [Bit] -> Q Exp
 bitsToExpr [] = error $ "Unexpected empty bit list"

--- a/src/Clash/Annotations/BitRepresentation/Deriving.hs
+++ b/src/Clash/Annotations/BitRepresentation/Deriving.hs
@@ -133,6 +133,7 @@ resolve :: NameMap -> Type -> Type
 resolve nmap (VarT n) = nmap Map.! n
 resolve nmap (AppT t1 t2) = AppT (resolve nmap t1) (resolve nmap t2)
 resolve _nmap t@(ConT _) = t
+resolve _nmap t@(LitT _) = t
 resolve _nmap t = error $ "Unexpected type: " ++ show t
 
 resolveCon :: NameMap -> Con -> Con

--- a/src/Clash/Annotations/BitRepresentation/Deriving.hs
+++ b/src/Clash/Annotations/BitRepresentation/Deriving.hs
@@ -54,7 +54,7 @@ module Clash.Annotations.BitRepresentation.Deriving
   ) where
 
 import Clash.Annotations.BitRepresentation
-  (DataReprAnn(..), ConstrRepr(..), BitMask, Value, Size, reprType)
+  (DataReprAnn(..), ConstrRepr(..), BitMask, Value, Size, liftQ)
 import Clash.Annotations.BitRepresentation.Internal
   (dataReprAnnToDataRepr', constrReprToConstrRepr', DataRepr'(..))
 import Clash.Annotations.BitRepresentation.Util
@@ -359,7 +359,7 @@ deriveDataRepr constrDerivator fieldsDerivator typ = do
                           constrValues
 
       [| DataReprAnn
-          $(reprType $ return typ)
+          $(liftQ $ return typ)
           ($dataSize + constrSize)
           $(listE constrReprs) |]
     _ ->

--- a/src/Clash/Annotations/BitRepresentation/Deriving.hs
+++ b/src/Clash/Annotations/BitRepresentation/Deriving.hs
@@ -1,313 +1,121 @@
-{-# LANGUAGE DeriveLift #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE MagicHash #-}
+{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE DeriveLift #-}
 
+module Clash.Annotations.BitRepresentation.Deriving
+  ( deriveDefaultAnnotation
+  ) where
 
-module Clash.Annotations.BitRepresentation.Deriving where
+import GHC.Exts
+import GHC.Integer.Logarithms
 
-import Prelude
+import Data.Bits (shiftL)
+import Data.Proxy (Proxy(..))
 
-import Clash.Annotations.BitRepresentation
-import Clash.Class.BitPack
+import qualified Data.Map as Map
 
-import Data.Bits
-import Data.List (mapAccumL)
-import Data.Proxy
-
-import Language.Haskell.TH
+import Language.Haskell.TH (listE, pragAnnD)
 import Language.Haskell.TH.Syntax
+import GHC.TypeLits (natVal)
 
-import GHC.Exts (Int(I#))
-import GHC.Integer.Logarithms (integerLog2#)
+import Clash.Class.BitPack
+import Clash.Annotations.BitRepresentation ( DataReprAnn(..)
+                                           , ConstrRepr(..)
+                                           , reprType
+                                           )
 
-deriveEncodingOneHot :: Q Type -> Q [Dec]
-deriveEncodingOneHot = generateModuleAnn encodingOneHot
-deriveEncodingOneHot' :: Q Type -> Q [Dec]
-deriveEncodingOneHot' = generateModuleAnn' encodingOneHot'
-
-deriveEncodingNormal :: Q Type -> Q [Dec]
-deriveEncodingNormal = generateModuleAnn encodingNormal
-
-deriveEncodingWide :: Q Type -> Q [Dec]
-deriveEncodingWide = generateModuleAnn encodingWide
-
-generateModuleAnn
-  :: (Q Type -> Q Exp)
-  -> Q Type
-  -> Q [Dec]
-generateModuleAnn derivationFunc typ
-  = do
-       let repr = derivationFunc typ
-       pragma <- pragAnnD ModuleAnnotation repr
-
-       -- we only really need the pragma, but the declaration is helpful
-       -- for debugging
-       typ' <- typ
-       nm <- newName $ "myRepr__" ++ typeToSafeName typ'
-       decl <- valD (varP nm) (normalB repr) []
-       tySig <- sigD nm [t| DataReprAnn |]
-       return [pragma, decl, tySig]
-
-generateModuleAnn'
-  :: (Q Type -> Q (Exp, [Dec]))
-  -> Q Type -> Q [Dec]
-generateModuleAnn' f q
-  = do
-       (repr,extras) <- f q
-       pragma <- pragAnnD ModuleAnnotation (return repr)
-
-       -- we only really need the pragma, but the declaration is helpful
-       -- for debugging
-       ty <- q
-       nm <- newName $ "myRepr__" ++ typeToSafeName ty
-       decl <- valD (varP nm) (normalB $ return repr) []
-       tySig <- sigD nm [t| DataReprAnn |]
-       return $ pragma : decl : tySig : extras
-
-typeToSafeName :: Type -> String
-typeToSafeName = map convertChars . show . ppr
-  where
-    convertChars c | c `elem` ". \t\n(),-" = '_'
-                   | otherwise = c
-
-encodingOneHot
-  :: Q Type
-  -> Q Exp
-encodingOneHot qty
-  = do ty <- qty
-       let tyNm = getTyNm ty
-       (TyConI tyCon) <- reify tyNm
-       let
-           constructors = getCons tyCon
-           width :: Integer
-           width = fromIntegral $ length constructors
-           f :: Int -> Con -> Q Exp
-           f n con = do
-             let conNm = conName con
-                 mask = 1 `shiftL` n :: Integer
-                 value = mask
-             [| ConstrRepr conNm mask value $(listE []) |]
-
-           reps :: [Q Exp]
-           reps = zipWith f [0..] constructors
-
-       [| DataReprAnn ty width $(listE reps) |]
-
--- hack that adds BitPack instance (without functional pack/unpack, just BitSize)
-encodingOneHot'
-  :: Q Type
-  -> Q (Exp,[Dec])
-encodingOneHot' qty = do
-  ty <- qty
-  let tyNm = getTyNm ty
-  (TyConI tyCon) <- reify tyNm
-  let
-      cs = getCons tyCon
-      width :: Integer
-      width = fromIntegral $ length cs
-      f :: Int -> Con -> Q Exp
-      f n con = do
-        let conNm = conName con
-            mask = 1 `shiftL` n :: Integer
-            value = mask
-        [| ConstrRepr conNm mask value $(listE []) |]
-
-      reps :: [Q Exp]
-      reps = zipWith f [0..] cs
-      body = [| DataReprAnn ty width $(listE reps) |]
-
-      extra = instanceD (return []) [t| BitPack $(qty) |] [declSize,declPack,declUnpack]
-      declPack = funD 'pack [clause [] (normalB $ varE 'undefined) []] -- TODO pack implementation
-      declUnpack = funD 'unpack [clause [] (normalB $ varE 'undefined) []] -- TODO idem for unpack
-      declSize = tySynInstD ''BitSize (tySynEqn [qty] (litT $ numTyLit width))
-
-  bodyE <- body
-  extraE <- extra
-  return (bodyE, [extraE])
+type NameMap = Map.Map Name Type
 
 
-encodingNormal
-  :: Q Type
-  -> Q Exp
-encodingNormal qty = do
-  ty <- qty
-  let tyNm = getTyNm ty
-  (TyConI tyCon) <- reify tyNm
-  let
-    cs = getCons tyCon
-    consWidth :: Integer
-    consWidth = integerLog2Ceil $ fromIntegral $ length cs
+integerLog2Ceil :: Integer -> Integer
+integerLog2Ceil n =
+  let nlog2 = fromIntegral $ I# (integerLog2# n) in
+  if n > 2^nlog2 then nlog2 + 1 else nlog2
 
-    fieldsOfConstrs = map fieldTypes cs
+tyVarBndrName :: TyVarBndr -> Name
+tyVarBndrName (PlainTV n) = n
+tyVarBndrName (KindedTV n _k) = n
 
-    allWidths :: [[Q Exp]]
-    allWidths = map (map typeSize) fieldsOfConstrs
-    allWidths' :: Q [[Exp]]
-    allWidths' = sequence $ map sequence allWidths
-    allWidths'' :: Q [Exp]
-    allWidths'' = fmap (fmap ListE) allWidths'
+-- | Replace Vars types given in mapping
+resolve :: NameMap -> Type -> Type
+resolve nmap (VarT n) = nmap Map.! n
+resolve nmap (AppT t1 t2) = AppT (resolve nmap t1) (resolve nmap t2)
+resolve _nmap t@(ConT _) = t
+resolve _nmap t = error $ {-$(curLoc) ++-} "Unexpected type: " ++ show t
 
-  allWidths''' <- allWidths'
+resolveCon :: NameMap -> Con -> Con
+resolveCon nmap (NormalC t (unzip -> (bangs, fTypes))) =
+  NormalC t $ zip bangs $ map (resolve nmap) fTypes
+resolveCon _name constr =
+  error $ {-$(curLoc) ++-} "Unexpected constructor: " ++ show constr
 
-  let
-    allWidths2 :: Q Exp
-    allWidths2 = [| map sum $(fmap ListE allWidths'') |]
-
-    fieldBits = [| maximum $(allWidths2) |]
-
-    width :: Q Exp
-    width = [| consWidth + $(fieldBits) |]
-
-    consMask = [| let w = $(width) in maskFromDownto (w-1) (w-consWidth) |]
-
-    f :: Integer -> Con -> [Exp] -> Q Exp
-    f n con fieldWidths = do
-      let conNm = conName con
-          value = [| n `shiftL` (fromIntegral $fieldBits)|]
-      [| ConstrRepr
-           conNm
-           $consMask
-           $value
-           (fieldAnnsNormal $(width) consWidth $(return $ ListE fieldWidths))
-           |]
-
-    reps :: [Q Exp]
-    reps = zipWith3 f [0..] cs allWidths'''
-
-  [| DataReprAnn ty $(width) $(listE reps) |]
-
--- | Construct field bitmasks for normal encoding
-fieldAnnsNormal :: Integer -> Integer -> [Integer] -> [Integer]
-fieldAnnsNormal totalWidth consWidth fieldWidths = go (totalWidth-consWidth) fieldWidths
-  where
-    go n (f:fs) = maskFromDownto (n-1) (n-f) : go (n-f) fs
-    go _ [] = []
-
-
-encodingWide :: Q Type -> Q Exp
-encodingWide qty = do
-  ty <- qty
-  let tyNm = getTyNm ty
-  (TyConI tyCon) <- reify tyNm
-  let
-    cs = getCons tyCon
-    consWidth :: Integer
-    consWidth = integerLog2Ceil $ fromIntegral $ length cs
-
-    fieldsOfConstrs = map fieldTypes cs
-
-    allWidths :: [[Q Exp]]
-    allWidths = map (map typeSize) fieldsOfConstrs
-    allWidths' :: Q [[Exp]]
-    allWidths' = sequence $ map sequence allWidths
-    allWidths'' :: Q [Exp]
-    allWidths'' = fmap (fmap ListE) allWidths'
-
-    allWidths2 :: Q Exp
-    allWidths2 = [| map sum $(fmap ListE allWidths'') |]
-
-    fieldBits = [| sum $allWidths2 |]
-
-    width :: Q Exp
-    width = [| consWidth + $fieldBits |]
-
-    consMask = [| let w = $width in maskFromDownto (w-1) (w-consWidth) |]
-
-    fieldMaskss :: Q Exp
-    fieldMaskss = [| fieldMasksWide $(width) consWidth $(fmap (ListE . fmap ListE) allWidths') |]
-
-    conNms = map conName cs
-    body  = [|
-      \consMaskE fieldBitsE fieldMaskssE ->
-        let reps = consRepsWide consMaskE fieldBitsE [0..] conNms fieldMaskssE in
-        DataReprAnn ty $width reps
-      |]
-
-  appsE [body, consMask, fieldBits, fieldMaskss]
-
-
-consRepWide
-  :: Integer
-  -> Integer
-  -> Integer
-  -> Name
-  -> [Integer]
-  -> ConstrRepr
-consRepWide consMask fieldBits n conNm fieldMasks =
- let value = n `shiftL` (fromIntegral fieldBits)
- in ConstrRepr conNm consMask value fieldMasks
-
-consRepsWide
-  :: Integer
-  -> Integer
-  -> [Integer]
-  -> [Name]
-  -> [[Integer]]
-  -> [ConstrRepr]
-consRepsWide consMask fieldBits conCodes conNms fieldMasks =
-    zipWith3 (consRepWide consMask fieldBits) conCodes conNms fieldMasks
-
-
-type BitSpan = (Integer,Integer)
-type BitMask = Integer
-
--- | Construct field bitmasks for wide encoding
-fieldMasksWide
-  :: Integer
-  -> Integer
-  -> [[Integer]]
-  -> [[Integer]]
-fieldMasksWide totalWidth consWidth fieldWidthss =
-  map (map maskSpan) $ fieldSpansWide totalWidth consWidth fieldWidthss
-
-fieldSpansWide
-  :: Integer
-  -> Integer
-  -> [[Integer]]
-  -> [[BitSpan]]
-fieldSpansWide totalWidth consWidth fieldWidthss =
-  let go a xss = snd $ mapAccumL (mapAccumL (\n w -> (n-w, (n,n-w+1)))) a xss in
-  go (totalWidth-consWidth-1) fieldWidthss
+collectTypeArgs :: Type -> (Type, [Type])
+collectTypeArgs t@(ConT _name) = (t, [])
+collectTypeArgs (AppT t1 t2) =
+  let (base, args) = collectTypeArgs t1 in
+  (base, args ++ [t2])
+collectTypeArgs t =
+  error $ {-$(curLoc) ++-} "Unexpected type: " ++ show t
 
 typeSize :: Type -> Q Exp
-typeSize ty = [| natVal (Proxy :: Proxy (BitSize $(return ty))) |]
+typeSize typ = do
+  bitSizeInstances <- reifyInstances ''BitSize [typ]
+  case bitSizeInstances of
+    [] ->
+      error $ {-$(curLoc) ++ -} unwords [
+          "Could not find custom bit representation nor BitSize instance"
+        , "for", show typ ++ "." ]
+    [TySynInstD _ (TySynEqn _ (LitT (NumTyLit n)))] ->
+      [| n |]
+    [_impl] ->
+      [| natVal (Proxy :: Proxy (BitSize $(return typ))) |]
+    unexp ->
+      error $ {-$(curLoc) ++ -} "Unexpected result from reifyInstances: " ++ show unexp
 
--- | Construct bitmask from i downto j (inclusive)
-maskFromDownto :: Integer -> Integer -> BitMask
-maskFromDownto i j
-  | i < j = error $ {-$(curLoc) ++-} show i ++ " must not be smaller then " ++ show j
-  | j < 0 = error $ {-$(curLoc) ++-} "lowerbound " ++ show j ++ " is smaller than 0"
-  | otherwise = maskBits i - maskBits (j-1)
+bitmask
+  :: Integer
+  -> Integer
+  -> Integer
+bitmask _start 0    = 0
+bitmask start  size = shiftL (2^size - 1) $ fromIntegral (start - (size - 1))
 
-maskSpan :: BitSpan -> BitMask
-maskSpan (i,j) = maskFromDownto i j
+buildConstrRepr
+  :: Q Exp
+  -- ^ Data size
+  -> Integer
+  -- ^ Number of bits reserved for constructor
+  -> Name
+  -- ^ Constr name
+  -> [Exp]
+  -- ^ Field sizes
+  -> Integer
+  -- ^ Constructor number
+  -> Q Exp
+buildConstrRepr dataSize constrSize constrName fieldSizes constrN = [|
+  ConstrRepr
+    constrName
+    $mask
+    $value
+    $(return $ ListE fieldSizes)
+  |]
+  where
+    mask = [| bitmask ($dataSize - 1) constrSize |]
+    value = [| shiftL constrN (fromIntegral $ $dataSize - 1)|]
 
--- | Construct bitmask with the n lowest bits set
-maskBits :: Integer -> BitMask
-maskBits n = (1 `shiftL` (fromIntegral $ n+1)) - 1
-
-getCons :: Dec -> [Con]
-getCons tyCon = case tyCon of
-  DataD _ _nm _tyVars _ cs _   -> cs
-  NewtypeD _ _nm _tyVars _ c _ -> [c]
-  _ -> error $ {-$(curLoc) ++-} "Can't derive encoding for a type synonym"
 
 fieldTypes :: Con -> [Type]
-fieldTypes con = case con of
-  NormalC _nm bTys -> map snd bTys
-  RecC    _nm vbTys -> map (\(_,_,ty) -> ty) vbTys
-  InfixC (_,ty1) _nm (_,ty2) -> [ty1,ty2]
-  _ -> error $ {-$(curLoc) ++-} "No support for constructors like: " ++ show con
-
-collectTyArgs :: Type -> Maybe (Name,[Type])
-collectTyArgs = go []
-  where
-    go args (AppT ty1 ty2) = go (ty2:args) ty1
-    go args (ConT nm) = Just (nm,args)
-    go _    _         = Nothing
+fieldTypes (NormalC _nm bTys) =
+  [ty | (_, ty) <- bTys]
+fieldTypes (RecC _nm bTys) =
+  [ty | (_, _, ty) <- bTys]
+fieldTypes (InfixC (_, ty1) _nm (_, ty2)) =
+  [ty1, ty2]
+fieldTypes con =
+  error $ {-$(curLoc) ++-} "Unexpected constructor type: " ++ show con
 
 conName :: Con -> Name
 conName c = case c of
@@ -316,22 +124,62 @@ conName c = case c of
   InfixC _ nm _ -> nm
   _ -> error $ {-$(curLoc) ++-} "No GADT support"
 
-getTyNm :: Type -> Name
-getTyNm ty =
-  case go ty of
-    Just t -> t
-    Nothing ->
-      error $ {-$(curLoc) ++-} unwords [ "can only handle type constants and"
-                                       , "type application, not:"
-                                       , show (ppr ty) ]
+constrFieldSizes
+  :: Con
+  -> Q (Name, [Exp])
+constrFieldSizes con = do
+  fieldSizes <- mapM typeSize (fieldTypes con)
+  return (conName con, fieldSizes)
 
-  where
-    go :: Type -> Maybe Name
-    go (ConT tyNm)  = Just tyNm
-    go (AppT ty1 _) = go ty1
-    go _            = Nothing
+-- | Derive DataRepr' for a specific type.
+deriveDataRepr :: Type -> Q Exp
+deriveDataRepr typ = do
+  info <- reify tyConstrName
+  case info of
+    (TyConI (DataD [] _constrName vars _kind dConstructors _clauses)) ->
+      let varMap = Map.fromList $ zip (map tyVarBndrName vars) typeArgs in
+      let resolvedConstructors = map (resolveCon varMap) dConstructors in do
 
-integerLog2Ceil :: Integer -> Integer
-integerLog2Ceil n =
-  let nlog2 = fromIntegral $ I# (integerLog2# n) in
-  if n > 2^nlog2 then nlog2 + 1 else nlog2
+      -- Get sizes and names of all constructors
+      (constrNames, fieldSizess) <-
+        unzip <$> (mapM constrFieldSizes resolvedConstructors)
+
+      let fieldSizess'  = ListE <$> fieldSizess
+      let fieldSizess'' = ListE fieldSizess'
+
+      -- Determine size of whole datatype
+      let constructorSizes = [| map sum $(return fieldSizess'') |]
+      let constrSize = integerLog2Ceil (fromIntegral $ length dConstructors)
+      let dataSize = [| constrSize + (maximum $constructorSizes) |]
+
+      -- Determine at which bits various fields start
+      let constrReprs = zipWith3
+                          (buildConstrRepr dataSize constrSize)
+                          constrNames
+                          fieldSizess
+                          [0..]
+
+      [| DataReprAnn $(reprType $ return typ)  $dataSize $(listE constrReprs)  |]
+    _ ->
+      error $ {-$(curLoc) ++-} "Could not derive dataRepr for: " ++ show info
+
+    where
+      (ConT tyConstrName, typeArgs) = collectTypeArgs typ
+
+-- | Derives BitPack instances for given type. Will account for custom bit
+-- representation annotations in the module where the splice is ran, and all
+-- modules of the types used in the data type. Note that the generated instance
+-- might conflict with existing implementations (for example, an instance for
+-- /Maybe a/ exists, yielding conflicts for any alternative implementations).
+--
+deriveDefaultAnnotation
+  :: Q Type
+  -> Q [Dec]
+deriveDefaultAnnotation typQ = do
+  typ <- typQ
+
+  typDataRepr <- deriveDataRepr typ
+
+  return <$> pragAnnD ModuleAnnotation (return typDataRepr)
+
+

--- a/src/Clash/Annotations/BitRepresentation/Internal.hs
+++ b/src/Clash/Annotations/BitRepresentation/Internal.hs
@@ -1,0 +1,118 @@
+{-|
+Copyright  :  (C) 2018, Google Inc.
+License    :  BSD2 (see the file LICENSE)
+Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
+-}
+
+{-# LANGUAGE DeriveAnyClass     #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE RankNTypes         #-}
+{-# LANGUAGE TemplateHaskell    #-}
+
+module Clash.Annotations.BitRepresentation.Internal
+  ( buildCustomReprs
+  , dataReprAnnToDataRepr'
+  , getConstrRepr
+  , getDataRepr
+  , thTypeToType'
+ , ConstrRepr'(..)
+ , DataRepr'(..)
+ , Type'(..)
+ , CustomReprs
+  ) where
+
+import           Clash.Annotations.BitRepresentation
+  (BitMask, Value, Size, FieldAnn, DataReprAnn(..), ConstrRepr(..))
+import           Control.DeepSeq                          (NFData)
+import           Data.Hashable                            (Hashable)
+import qualified Data.Map                                 as Map
+import qualified Data.Text.Lazy                           as Text
+import           Data.Typeable                            (Typeable)
+import qualified Language.Haskell.TH.Lib                  as TH
+import qualified Language.Haskell.TH.Syntax               as TH
+import           GHC.Generics                             (Generic)
+
+
+-- | Simple version of template haskell type. Used internally to match on.
+data Type'
+  = AppTy' Type' Type'
+  -- ^ Type application
+  | ConstTy' Text.Text
+  -- ^ Qualified name of type
+  | LitTy' Integer
+  -- ^ Numeral literal (used in BitVector 10, for example)
+    deriving (Generic, NFData, Eq, Typeable, Hashable, Ord, Show)
+
+-- | Internal version of DataRepr
+data DataRepr' =
+  DataRepr'
+    -- Qualified name of type (recursive):
+    Type'
+    -- Size of data type:
+    Size
+    -- Constructors:
+    [ConstrRepr']
+      deriving (Show, Generic, NFData, Eq, Typeable, Hashable, Ord)
+
+-- | Internal version of ConstRepr
+data ConstrRepr' =
+  ConstrRepr'
+    -- Qualified name of constructor:
+    Text.Text
+    -- Syntactical position in the custom representations definition:
+    Int
+    -- Mask needed to determine constructor:
+    BitMask
+    -- Value after applying mask:
+    Value
+    -- Indicates where fields are stored:
+    [FieldAnn]
+      deriving (Show, Generic, NFData, Eq, Typeable, Ord, Hashable)
+
+dataReprAnnToDataRepr' :: DataReprAnn -> DataRepr'
+dataReprAnnToDataRepr' (DataReprAnn typ size constrs) =
+  DataRepr' (thTypeToType' typ) size (zipWith toConstrRepr' [0..] constrs)
+    where
+      toConstrRepr' :: Int -> ConstrRepr -> ConstrRepr'
+      toConstrRepr' n (ConstrRepr name mask value fieldanns) =
+        ConstrRepr' (thToText name) n mask value (map fromIntegral fieldanns)
+
+thToText :: TH.Name -> Text.Text
+thToText (TH.Name (TH.OccName name') (TH.NameG _namespace _pkgName (TH.ModName modName))) =
+  Text.pack $ modName ++ "." ++ name'
+thToText name' = error $ "Unexpected pattern: " ++ show name'
+
+-- | Convert template haskell type to simple representation of type
+thTypeToType' :: TH.Type -> Type'
+thTypeToType' ty = go ty
+  where
+    go (TH.ConT name')   = ConstTy' (thToText name')
+    go (TH.AppT ty1 ty2) = AppTy' (go ty1) (go ty2)
+    go (TH.LitT (TH.NumTyLit n)) = LitTy' n
+    go _ = error $ "Unsupported type: " ++ show ty
+
+-- | Convenience type for index built by buildCustomReprs
+type CustomReprs =
+  ( Map.Map Type' DataRepr'
+  , Map.Map Text.Text ConstrRepr'
+  )
+
+-- | Lookup data type representation based on name
+getDataRepr :: Type' -> CustomReprs -> Maybe DataRepr'
+getDataRepr name (reprs, _) = Map.lookup name reprs
+
+-- | Lookup constructor representation based on name
+getConstrRepr :: Text.Text -> CustomReprs -> Maybe ConstrRepr'
+getConstrRepr name (_, reprs) = Map.lookup name reprs
+
+-- | Add CustomRepr to existing index
+buildCustomRepr :: CustomReprs -> DataRepr' -> CustomReprs
+buildCustomRepr (dMap, cMap) d@(DataRepr' name _size constrReprs) =
+  let insertConstr c@(ConstrRepr' name' _ _ _ _) cMap' = Map.insert name' c cMap' in
+  (Map.insert name d dMap, foldr insertConstr cMap constrReprs)
+
+-- | Create indices based on names of constructors and data types
+buildCustomReprs :: [DataRepr'] -> CustomReprs
+buildCustomReprs = foldl buildCustomRepr (Map.empty, Map.empty)

--- a/src/Clash/Annotations/BitRepresentation/Internal.hs
+++ b/src/Clash/Annotations/BitRepresentation/Internal.hs
@@ -30,7 +30,6 @@ import           Data.Hashable                            (Hashable)
 import qualified Data.Map                                 as Map
 import qualified Data.Text.Lazy                           as Text
 import           Data.Typeable                            (Typeable)
-import qualified Language.Haskell.TH.Lib                  as TH
 import qualified Language.Haskell.TH.Syntax               as TH
 import           GHC.Generics                             (Generic)
 

--- a/src/Clash/Annotations/BitRepresentation/Internal.hs
+++ b/src/Clash/Annotations/BitRepresentation/Internal.hs
@@ -17,10 +17,10 @@ module Clash.Annotations.BitRepresentation.Internal
   , getConstrRepr
   , getDataRepr
   , thTypeToType'
- , ConstrRepr'(..)
- , DataRepr'(..)
- , Type'(..)
- , CustomReprs
+  , ConstrRepr'(..)
+  , DataRepr'(..)
+  , Type'(..)
+  , CustomReprs
   ) where
 
 import           Clash.Annotations.BitRepresentation

--- a/src/Clash/Annotations/BitRepresentation/Internal.hs
+++ b/src/Clash/Annotations/BitRepresentation/Internal.hs
@@ -14,6 +14,7 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 module Clash.Annotations.BitRepresentation.Internal
   ( buildCustomReprs
   , dataReprAnnToDataRepr'
+  , constrReprToConstrRepr'
   , getConstrRepr
   , getDataRepr
   , thTypeToType'
@@ -70,13 +71,13 @@ data ConstrRepr' =
     [FieldAnn]
       deriving (Show, Generic, NFData, Eq, Typeable, Ord, Hashable)
 
+constrReprToConstrRepr' :: Int -> ConstrRepr -> ConstrRepr'
+constrReprToConstrRepr' n (ConstrRepr name mask value fieldanns) =
+  ConstrRepr' (thToText name) n mask value (map fromIntegral fieldanns)
+
 dataReprAnnToDataRepr' :: DataReprAnn -> DataRepr'
 dataReprAnnToDataRepr' (DataReprAnn typ size constrs) =
-  DataRepr' (thTypeToType' typ) size (zipWith toConstrRepr' [0..] constrs)
-    where
-      toConstrRepr' :: Int -> ConstrRepr -> ConstrRepr'
-      toConstrRepr' n (ConstrRepr name mask value fieldanns) =
-        ConstrRepr' (thToText name) n mask value (map fromIntegral fieldanns)
+  DataRepr' (thTypeToType' typ) size (zipWith constrReprToConstrRepr' [0..] constrs)
 
 thToText :: TH.Name -> Text.Text
 thToText (TH.Name (TH.OccName name') (TH.NameG _namespace _pkgName (TH.ModName modName))) =

--- a/src/Clash/Annotations/BitRepresentation/Util.hs
+++ b/src/Clash/Annotations/BitRepresentation/Util.hs
@@ -8,6 +8,7 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 
 module Clash.Annotations.BitRepresentation.Util
   ( bitOrigins
+  , bitOrigins'
   , bitRanges
   , isContinuousMask
   , BitOrigin(..)
@@ -46,33 +47,15 @@ data BitOrigin
       -- End bit (inclusive, ..downto)
         deriving (Show)
 
--- | Given a type size and one of its constructor this function will yield a
--- specification of which bits the whole type is made up of. I.e., a
--- construction plan on how to make the whole data structure, given its
--- individual constructor fields.
-bitOrigins
+-- | Same as bitOrigins, but each item in result list represents a single bit.
+bitOrigins'
   :: DataRepr'
   -> ConstrRepr'
   -> [BitOrigin]
-bitOrigins (DataRepr' _ size constrs) (ConstrRepr' _ _ mask value fields) =
-  mergeOrigins origins
+bitOrigins' (DataRepr' _ size constrs) (ConstrRepr' _ _ mask value fields) =
+  map bitOrigin (reverse [0..fromIntegral $ size - 1])
     where
       commonMask = foldl (.|.) 0 [m | ConstrRepr' _ _ m _ _ <- constrs]
-      origins = map bitOrigin (reverse [0..fromIntegral $ size - 1])
-
-      -- | Merge consequtive Constructor and Field fields (if applicable).
-      mergeOrigins :: [BitOrigin] -> [BitOrigin]
-      mergeOrigins (Lit n : Lit n' : fs) =
-        -- Literals can always be merged:
-        mergeOrigins $ Lit (n ++ n') : fs
-      mergeOrigins (Field n s e : Field n' s' e' : fs)
-        -- Consequtive fields with same field number merged:
-        | n == n'   = mergeOrigins $ Field n s e' : fs
-        -- No merge:
-        | otherwise = Field n s e : mergeOrigins (Field n' s' e' : fs)
-      -- Base cases:
-      mergeOrigins (x:fs) = x : mergeOrigins fs
-      mergeOrigins []     = []
 
       -- | Determine origin of single bit
       bitOrigin :: Int -> BitOrigin
@@ -98,6 +81,31 @@ bitOrigins (DataRepr' _ size constrs) (ConstrRepr' _ _ mask value fields) =
                                      $ take n
                                      $ bitsToBools (fields !! fieldn) in
               Field fieldn fieldbitn fieldbitn
+
+-- | Given a type size and one of its constructor this function will yield a
+-- specification of which bits the whole type is made up of. I.e., a
+-- construction plan on how to make the whole data structure, given its
+-- individual constructor fields.
+bitOrigins
+  :: DataRepr'
+  -> ConstrRepr'
+  -> [BitOrigin]
+bitOrigins dataRepr constrRepr =
+  mergeOrigins (bitOrigins' dataRepr constrRepr)
+
+-- | Merge consequtive Constructor and Field fields (if applicable).
+mergeOrigins :: [BitOrigin] -> [BitOrigin]
+mergeOrigins (Lit n : Lit n' : fs) =
+  -- Literals can always be merged:
+  mergeOrigins $ Lit (n ++ n') : fs
+mergeOrigins (Field n s e : Field n' s' e' : fs)
+  -- Consequtive fields with same field number merged:
+  | n == n'   = mergeOrigins $ Field n s e' : fs
+  -- No merge:
+  | otherwise = Field n s e : mergeOrigins (Field n' s' e' : fs)
+-- Base cases:
+mergeOrigins (x:fs) = x : mergeOrigins fs
+mergeOrigins []     = []
 
 -- | Convert a number to a list of its bits
 -- Output is ordered from least to most significant bit.

--- a/src/Clash/Annotations/BitRepresentation/Util.hs
+++ b/src/Clash/Annotations/BitRepresentation/Util.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE TemplateHaskell #-}
 module Clash.Annotations.BitRepresentation.Util
   ( bitOrigins
   , bitRanges
@@ -12,21 +12,29 @@ import Data.Tuple (swap)
 import Data.List  (findIndex, group, mapAccumL)
 import Data.Bits  (Bits, testBit, testBit, shiftR)
 
-data Bit = H
-         | L
-         | U
-          deriving (Show,Eq)
+data Bit
+  -- | High
+  = H
+  -- | Low
+  | L
+  -- | Undefined
+  | U
+    deriving (Show,Eq)
 
--- |
+-- | Result of various utilty functions. Indicates the origin of a certain bit:
+-- either a literal from the constructor (or an undefined bit), or from a
+-- literal.
 data BitOrigin
+  -- | Literal (high, low, undefind)
   = Lit [Bit]
+  -- | Bits originate from a field. Field /fieldnr/ /from/ /downto/.
   | Field
       Int
-      -- ^ Field number
+      -- Field number
       Int
-      -- ^ Start bit (from..)
+      -- Start bit (from..)
       Int
-      -- ^ End bit (inclusive, ..downto)
+      -- End bit (inclusive, ..downto)
         deriving (Show)
 
 -- | Given a type size and one of its constructor this function will yield a

--- a/src/Clash/Annotations/BitRepresentation/Util.hs
+++ b/src/Clash/Annotations/BitRepresentation/Util.hs
@@ -1,0 +1,120 @@
+{-# LANGUAGE TemplateHaskell   #-}
+module Clash.Annotations.BitRepresentation.Util
+  ( bitOrigins
+  , bitRanges
+  , isContinuousMask
+  , BitOrigin(..)
+  , Bit(..)
+  ) where
+
+
+import Data.Tuple (swap)
+import Data.List  (findIndex, group, mapAccumL)
+import Data.Bits  (Bits, testBit, testBit, shiftR)
+
+data Bit = H
+         | L
+         | U
+          deriving (Show,Eq)
+
+-- |
+data BitOrigin
+  = Lit [Bit]
+  | Field
+      Int
+      -- ^ Field number
+      Int
+      -- ^ Start bit (from..)
+      Int
+      -- ^ End bit (inclusive, ..downto)
+        deriving (Show)
+
+-- | Given a type size and one of its constructor this function will yield a
+-- specification of which bits the whole type is made up of. I.e., a
+-- construction plan on how to make the whole data structure, given its
+-- individual constructor fields.
+bitOrigins
+  :: Int
+  -> (Integer, Integer, [Integer])
+  -- ^ (mask, value, fields) from CustomRepr or CustomRepr'
+  -> [BitOrigin]
+bitOrigins size cRepr = mergeOrigins origins
+    where
+      origins = map (bitOrigin cRepr) (reverse [0..fromIntegral $ size - 1])
+
+      -- | Merge consequtive Constructor and Field fields (if applicable).
+      mergeOrigins :: [BitOrigin] -> [BitOrigin]
+      mergeOrigins (Lit n : Lit n' : fs) =
+        -- Literals can always be merged:
+        mergeOrigins $ Lit (n ++ n') : fs
+      mergeOrigins (Field n s e : Field n' s' e' : fs)
+        -- Consequtive fields with same field number merged:
+        | n == n'   = mergeOrigins $ Field n s e' : fs
+        -- No merge:
+        | otherwise = Field n s e : mergeOrigins (Field n' s' e' : fs)
+      -- Base cases:
+      mergeOrigins (x:fs) = x : mergeOrigins fs
+      mergeOrigins []     = []
+
+      -- | Determine origin of single bit
+      bitOrigin :: (Integer, Integer, [Integer]) -> Int -> BitOrigin
+      bitOrigin (mask, value, fields) n =
+        if testBit mask n then
+          Lit [if testBit value n then H else L]
+        else
+          case findIndex (\fmask -> testBit fmask n) fields of
+            Nothing ->
+              Lit [U]
+            Just fieldn ->
+              let fieldbitn = length $ filter id
+                                     $ take n
+                                     $ bitsToBools (fields !! fieldn) in
+              Field fieldn fieldbitn fieldbitn
+
+-- | Convert a number to a list of its bits
+-- Output is ordered from least to most significant bit.
+-- Only outputs bits until the highest set bit.
+--
+-- >>> map bitsToBools [0..2]
+-- [[],[True],[False,True]])
+--
+-- This also works for variable sized number like Integer.
+-- But not for negative numbers, because negative Integers have infinite bits set.
+bitsToBools :: (Num a, Bits a, Ord a) => a -> [Bool]
+bitsToBools 0 = []
+bitsToBools n | n < 0 = error "Can't deal with negative bitmasks/values"
+              | otherwise = testBit n 0 : bitsToBools (n `shiftR` 1)
+
+
+offsets
+  :: Int
+  -- ^ Offset
+  -> [Bool]
+  -- ^ Group
+  -> (Int, (Int, [Bool]))
+offsets offset group' =
+  (length group' + offset, (offset, group'))
+
+-- | Determine consecutively set bits in word. Will produce ranges from high
+-- to low. Examples:
+--
+--   bitRanges 0b10          == [(1,1)]
+--   bitRanges 0b101         == [(2,2),(0,0)]
+--   bitRanges 0b10011001111 == [(10,10),(7,6),(3,0)]
+--
+bitRanges :: Integer -> [(Int, Int)]
+bitRanges word = reverse $ map swap ranges
+  where
+    ranges  = map (\(ofs, grp) -> (ofs, ofs+length grp-1)) groups'
+    groups' = filter (head . snd) groups
+    groups  = snd $ mapAccumL offsets 0 (group bits)
+    bits    = bitsToBools word
+
+isContinuousMask :: Integer -> Bool
+isContinuousMask word =
+  -- Use case expression so we avoid calculating all groups
+  case bitRanges word of
+    -- At least two groups:
+    (_:_:_) -> False
+    -- Zero or one group:
+    _       -> True

--- a/src/Clash/Annotations/BitRepresentation/Util.hs
+++ b/src/Clash/Annotations/BitRepresentation/Util.hs
@@ -1,4 +1,11 @@
+{-|
+Copyright  :  (C) 2018, Google Inc.
+License    :  BSD2 (see the file LICENSE)
+Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
+-}
+
 {-# LANGUAGE TemplateHaskell #-}
+
 module Clash.Annotations.BitRepresentation.Util
   ( bitOrigins
   , bitRanges

--- a/src/Clash/Class/BitPack.hs
+++ b/src/Clash/Class/BitPack.hs
@@ -115,7 +115,7 @@ instance BitPack Bool where
   pack True  = 1
   pack False = 0
 
-  unpack = checkUnpackUndef $ \bv -> if bv == 1 then True else False
+  unpack bv = if bv == 1 then True else False
 
 instance BitPack (BitVector n) where
   type BitSize (BitVector n) = n
@@ -130,92 +130,92 @@ instance BitPack Bit where
 instance BitPack Int where
   type BitSize Int = WORD_SIZE_IN_BITS
   pack   = fromIntegral
-  unpack = checkUnpackUndef fromIntegral
+  unpack = fromIntegral
 
 instance BitPack Int8 where
   type BitSize Int8 = 8
   pack   = fromIntegral
-  unpack = checkUnpackUndef fromIntegral
+  unpack = fromIntegral
 
 instance BitPack Int16 where
   type BitSize Int16 = 16
   pack   = fromIntegral
-  unpack = checkUnpackUndef fromIntegral
+  unpack = fromIntegral
 
 instance BitPack Int32 where
   type BitSize Int32 = 32
   pack   = fromIntegral
-  unpack = checkUnpackUndef fromIntegral
+  unpack = fromIntegral
 
 #if WORD_SIZE_IN_BITS >= 64
 instance BitPack Int64 where
   type BitSize Int64 = 64
   pack   = fromIntegral
-  unpack = checkUnpackUndef fromIntegral
+  unpack = fromIntegral
 #endif
 
 instance BitPack Word where
   type BitSize Word = WORD_SIZE_IN_BITS
   pack   = fromIntegral
-  unpack = checkUnpackUndef fromIntegral
+  unpack = fromIntegral
 
 instance BitPack Word8 where
   type BitSize Word8 = 8
   pack   = fromIntegral
-  unpack = checkUnpackUndef fromIntegral
+  unpack = fromIntegral
 
 instance BitPack Word16 where
   type BitSize Word16 = 16
   pack   = fromIntegral
-  unpack = checkUnpackUndef fromIntegral
+  unpack = fromIntegral
 
 instance BitPack Word32 where
   type BitSize Word32 = 32
   pack   = fromIntegral
-  unpack = checkUnpackUndef fromIntegral
+  unpack = fromIntegral
 
 #if WORD_SIZE_IN_BITS >= 64
 instance BitPack Word64 where
   type BitSize Word64 = 64
   pack   = fromIntegral
-  unpack = checkUnpackUndef fromIntegral
+  unpack = fromIntegral
 #endif
 
 instance BitPack Float where
   type BitSize Float = 32
   pack   = packFloat#
-  unpack = checkUnpackUndef unpackFloat#
+  unpack = unpackFloat#
 
 packFloat# :: Float -> BitVector 32
 packFloat# = fromIntegral . floatToWord
 {-# NOINLINE packFloat# #-}
 
 unpackFloat# :: BitVector 32 -> Float
-unpackFloat# = wordToFloat . fromInteger . unsafeToInteger
+unpackFloat# = checkUnpackUndef $ wordToFloat . fromInteger . unsafeToInteger
 {-# NOINLINE unpackFloat# #-}
 
 instance BitPack Double where
   type BitSize Double = 64
   pack   = packDouble#
-  unpack = checkUnpackUndef unpackDouble#
+  unpack = unpackDouble#
 
 packDouble# :: Double -> BitVector 64
 packDouble# = fromIntegral . doubleToWord
 {-# NOINLINE packDouble# #-}
 
 unpackDouble# :: BitVector 64 -> Double
-unpackDouble# = wordToDouble . fromInteger . unsafeToInteger
+unpackDouble# = checkUnpackUndef $ wordToDouble . fromInteger . unsafeToInteger
 {-# NOINLINE unpackDouble# #-}
 
 instance BitPack CUShort where
   type BitSize CUShort = 16
   pack   = fromIntegral
-  unpack = checkUnpackUndef fromIntegral
+  unpack = fromIntegral
 
 instance BitPack Half where
   type BitSize Half = 16
   pack (Half x) = pack x
-  unpack        = checkUnpackUndef $ \x -> Half (unpack x)
+  unpack        = Half . unpack
 
 instance BitPack () where
   type BitSize () = 0

--- a/src/Clash/Class/BitPack.hs
+++ b/src/Clash/Class/BitPack.hs
@@ -115,7 +115,7 @@ instance BitPack Bool where
   pack True  = 1
   pack False = 0
 
-  unpack bv = if bv == 1 then True else False
+  unpack = checkUnpackUndef $ \bv -> if bv == 1 then True else False
 
 instance BitPack (BitVector n) where
   type BitSize (BitVector n) = n
@@ -130,92 +130,92 @@ instance BitPack Bit where
 instance BitPack Int where
   type BitSize Int = WORD_SIZE_IN_BITS
   pack   = fromIntegral
-  unpack = fromIntegral
+  unpack = checkUnpackUndef fromIntegral
 
 instance BitPack Int8 where
   type BitSize Int8 = 8
   pack   = fromIntegral
-  unpack = fromIntegral
+  unpack = checkUnpackUndef fromIntegral
 
 instance BitPack Int16 where
   type BitSize Int16 = 16
   pack   = fromIntegral
-  unpack = fromIntegral
+  unpack = checkUnpackUndef fromIntegral
 
 instance BitPack Int32 where
   type BitSize Int32 = 32
   pack   = fromIntegral
-  unpack = fromIntegral
+  unpack = checkUnpackUndef fromIntegral
 
 #if WORD_SIZE_IN_BITS >= 64
 instance BitPack Int64 where
   type BitSize Int64 = 64
   pack   = fromIntegral
-  unpack = fromIntegral
+  unpack = checkUnpackUndef fromIntegral
 #endif
 
 instance BitPack Word where
   type BitSize Word = WORD_SIZE_IN_BITS
   pack   = fromIntegral
-  unpack = fromIntegral
+  unpack = checkUnpackUndef fromIntegral
 
 instance BitPack Word8 where
   type BitSize Word8 = 8
   pack   = fromIntegral
-  unpack = fromIntegral
+  unpack = checkUnpackUndef fromIntegral
 
 instance BitPack Word16 where
   type BitSize Word16 = 16
   pack   = fromIntegral
-  unpack = fromIntegral
+  unpack = checkUnpackUndef fromIntegral
 
 instance BitPack Word32 where
   type BitSize Word32 = 32
   pack   = fromIntegral
-  unpack = fromIntegral
+  unpack = checkUnpackUndef fromIntegral
 
 #if WORD_SIZE_IN_BITS >= 64
 instance BitPack Word64 where
   type BitSize Word64 = 64
   pack   = fromIntegral
-  unpack = fromIntegral
+  unpack = checkUnpackUndef fromIntegral
 #endif
 
 instance BitPack Float where
   type BitSize Float = 32
   pack   = packFloat#
-  unpack = unpackFloat#
+  unpack = checkUnpackUndef unpackFloat#
 
 packFloat# :: Float -> BitVector 32
 packFloat# = fromIntegral . floatToWord
 {-# NOINLINE packFloat# #-}
 
 unpackFloat# :: BitVector 32 -> Float
-unpackFloat# = checkUnpackUndef $ wordToFloat . fromInteger . unsafeToInteger
+unpackFloat# = wordToFloat . fromInteger . unsafeToInteger
 {-# NOINLINE unpackFloat# #-}
 
 instance BitPack Double where
   type BitSize Double = 64
   pack   = packDouble#
-  unpack = unpackDouble#
+  unpack = checkUnpackUndef unpackDouble#
 
 packDouble# :: Double -> BitVector 64
 packDouble# = fromIntegral . doubleToWord
 {-# NOINLINE packDouble# #-}
 
 unpackDouble# :: BitVector 64 -> Double
-unpackDouble# = checkUnpackUndef $ wordToDouble . fromInteger . unsafeToInteger
+unpackDouble# = wordToDouble . fromInteger . unsafeToInteger
 {-# NOINLINE unpackDouble# #-}
 
 instance BitPack CUShort where
   type BitSize CUShort = 16
   pack   = fromIntegral
-  unpack = fromIntegral
+  unpack = checkUnpackUndef fromIntegral
 
 instance BitPack Half where
   type BitSize Half = 16
   pack (Half x) = pack x
-  unpack        = Half . unpack
+  unpack        = checkUnpackUndef $ \x -> Half (unpack x)
 
 instance BitPack () where
   type BitSize () = 0

--- a/src/Clash/Prelude/BitReduction.hs
+++ b/src/Clash/Prelude/BitReduction.hs
@@ -48,7 +48,7 @@ reduceAnd v = reduceAnd# (pack v)
 -- 00_0000
 -- >>> reduceOr (0 :: Signed 6)
 -- 0
-reduceOr :: BitPack a => a -> Bit
+reduceOr :: (BitPack a, KnownNat (BitSize a)) => a -> Bit
 reduceOr v = reduceOr# (pack v)
 
 {-# INLINE reduceXor #-}
@@ -66,5 +66,5 @@ reduceOr v = reduceOr# (pack v)
 -- 11_1011
 -- >>> reduceXor (-5 :: Signed 6)
 -- 1
-reduceXor :: BitPack a => a -> Bit
+reduceXor :: (BitPack a, KnownNat (BitSize a)) => a -> Bit
 reduceXor v = reduceXor# (pack v)

--- a/src/Clash/Prelude/Testbench.hs
+++ b/src/Clash/Prelude/Testbench.hs
@@ -17,6 +17,7 @@ module Clash.Prelude.Testbench
     assert
   , stimuliGenerator
   , outputVerifier
+  , outputVerifierBitVector
   )
 where
 
@@ -25,6 +26,7 @@ import GHC.TypeLits                       (KnownNat)
 import qualified Clash.Explicit.Testbench as E
 import           Clash.Signal
   (HiddenClockReset, Signal, hideClockReset)
+import Clash.Sized.BitVector              (BitVector)
 import Clash.Sized.Vector                 (Vec)
 import Clash.XException                   (ShowX)
 
@@ -108,6 +110,8 @@ stimuliGenerator = hideClockReset E.stimuliGenerator
 -- cycle(system10000): 9, outputVerifier
 -- expected value: 10, not equal to actual value: 9
 -- ,False,True,True]
+--
+-- If your working with 'BitVector's containing don't care bit you should use 'outputVerifierBitVector'.
 outputVerifier
   :: (KnownNat l, Eq a, ShowX a, HiddenClockReset domain gated synchronous)
   => Vec l a     -- ^ Samples to compare with
@@ -115,3 +119,14 @@ outputVerifier
   -> Signal domain Bool -- ^ Indicator that all samples are verified
 outputVerifier = hideClockReset E.outputVerifier
 {-# INLINE outputVerifier #-}
+
+
+-- | Same as 'outputVerifier',
+-- but can handle don't care bits in it's expected values.
+outputVerifierBitVector
+  :: (KnownNat l, KnownNat n, HiddenClockReset domain gated synchronous)
+  => Vec l (BitVector n)     -- ^ Samples to compare with
+  -> Signal domain (BitVector n)    -- ^ Signal to verify
+  -> Signal domain Bool -- ^ Indicator that all samples are verified
+outputVerifierBitVector = hideClockReset E.outputVerifierBitVector
+{-# INLINE outputVerifierBitVector #-}

--- a/src/Clash/Sized/Index.hs
+++ b/src/Clash/Sized/Index.hs
@@ -11,6 +11,7 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 {-# LANGUAGE Trustworthy #-}
 
 {-# OPTIONS_GHC -fplugin GHC.TypeLits.Extra.Solver -fplugin GHC.TypeLits.KnownNat.Solver #-}
+{-# OPTIONS_GHC -fplugin GHC.TypeLits.Normalise  #-}
 {-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# OPTIONS_HADDOCK show-extensions #-}
 

--- a/src/Clash/Sized/Internal/BitVector.hs
+++ b/src/Clash/Sized/Internal/BitVector.hs
@@ -943,8 +943,10 @@ checkUnpackUndef _ bv = res
 
 -- | Create a BitVector with all its bits undefined
 undefined# :: forall n . KnownNat n => BitVector n
-undefined# = let m = 1 `shiftL` fromInteger (natVal (Proxy @n))
-            in  BV (m-1) 0
+undefined# =
+  let m = 1 `shiftL` fromInteger (natVal (Proxy @n))
+  in  BV (m-1) 0
+{-# NOINLINE undefined# #-}
 
 -- | Check if one BitVector is like another.
 -- Undefined bits in the second argument are interpreted as don't care bits.
@@ -967,3 +969,4 @@ isLike (BV cMask c) (BV eMask e) = e' == c' && e' == c''
     c' = (c .&. complement cMask) .&. complement eMask
     -- | checked with undefined bits set to 1
     c'' = (c .|. cMask) .&. complement eMask
+{-# NOINLINE isLike #-}

--- a/src/Clash/Sized/Internal/BitVector.hs
+++ b/src/Clash/Sized/Internal/BitVector.hs
@@ -939,7 +939,7 @@ checkUnpackUndef _ bv = res
   where
     ty = typeOf res
     res = undefError (show ty ++ ".unpack") [bv]
-
+{-# NOINLINE checkUnpackUndef #-}
 
 -- | Create a BitVector with all its bits undefined
 undefined# :: forall n . KnownNat n => BitVector n

--- a/src/Clash/Sized/Internal/BitVector.hs
+++ b/src/Clash/Sized/Internal/BitVector.hs
@@ -215,11 +215,11 @@ instance Eq Bit where
   (/=) = neq##
 
 eq## :: Bit -> Bit -> Bool
-eq## (Bit _ b1) (Bit _ b2) = b1 == b2
+eq## b1 b2 = eq# (pack# b1) (pack# b2)
 {-# NOINLINE eq## #-}
 
 neq## :: Bit -> Bit -> Bool
-neq## (Bit _ b1) (Bit _ b2) = b1 == b2
+neq## b1 b2 = neq# (pack# b1) (pack# b2)
 {-# NOINLINE neq## #-}
 
 instance Ord Bit where
@@ -229,13 +229,13 @@ instance Ord Bit where
   (>=) = ge##
 
 lt##,ge##,gt##,le## :: Bit -> Bit -> Bool
-lt## (Bit _ n) (Bit _ m) = n < m
+lt## b1 b2 = lt# (pack# b1) (pack# b2)
 {-# NOINLINE lt## #-}
-ge## (Bit _ n) (Bit _ m) = n >= m
+ge## b1 b2 = ge# (pack# b1) (pack# b2)
 {-# NOINLINE ge## #-}
-gt## (Bit _ n) (Bit _ m) = n > m
+gt## b1 b2 = gt# (pack# b1) (pack# b2)
 {-# NOINLINE gt## #-}
-le## (Bit _ n) (Bit _ m) = n <= m
+le## b1 b2 = le# (pack# b1) (pack# b2)
 {-# NOINLINE le## #-}
 
 instance Enum Bit where
@@ -300,18 +300,17 @@ instance FiniteBits Bit where
   countTrailingZeros b = if eq## b low then 1 else 0
 
 and##, or##, xor## :: Bit -> Bit -> Bit
-and## (Bit _ v1) (Bit _ v2) = Bit 0 (v1 .&. v2)
+and## b1 b2 = unpack# $ and# (pack# b1) (pack# b2)
 {-# NOINLINE and## #-}
 
-or## (Bit _ v1) (Bit _ v2) = Bit 0 (v1 .|. v2)
+or## b1 b2 = unpack# $ or# (pack# b1) (pack# b2)
 {-# NOINLINE or## #-}
 
-xor## (Bit _ v1) (Bit _ v2) = Bit 0 (v1 `xor` v2)
+xor## b1 b2 = unpack# $ xor# (pack# b1) (pack# b2)
 {-# NOINLINE xor## #-}
 
 complement## :: Bit -> Bit
-complement## (Bit _ 0) = Bit 0 1
-complement## _         = Bit 0 0
+complement## = unpack# . complement# . pack#
 {-# NOINLINE complement## #-}
 
 -- *** BitPack

--- a/src/Clash/Sized/Internal/BitVector.hs
+++ b/src/Clash/Sized/Internal/BitVector.hs
@@ -160,19 +160,23 @@ import {-# SOURCE #-} qualified Clash.Sized.Internal.Index as I
 --
 -- * Bit indices are descending
 -- * 'Num' instance performs /unsigned/ arithmetic.
-newtype BitVector (n :: Nat) =
+data BitVector (n :: Nat) =
     -- | The constructor, 'BV', and  the field, 'unsafeToInteger', are not
     -- synthesisable.
-    BV { unsafeToInteger :: Integer}
+    BV { unsafeMask      :: Integer
+       , unsafeToInteger :: Integer
+       }
   deriving (Data,Undefined)
 
 -- * Bit
 
 -- | Bit
-newtype Bit =
+data Bit =
   -- | The constructor, 'Bit', and  the field, 'unsafeToInteger#', are not
   -- synthesisable.
-  Bit { unsafeToInteger# :: Integer}
+  Bit { unsafeMask#      :: Integer
+      , unsafeToInteger# :: Integer
+      }
   deriving (Data,Undefined)
 
 -- * Constructions
@@ -180,29 +184,30 @@ newtype Bit =
 {-# NOINLINE high #-}
 -- | logic '1'
 high :: Bit
-high = Bit 1
+high = Bit 0 1
 
 {-# NOINLINE low #-}
 -- | logic '0'
 low :: Bit
-low = Bit 0
+low = Bit 0 0
 
 -- ** Instances
 instance NFData Bit where
-  rnf (Bit i) = rnf i `seq` ()
+  rnf (Bit m i) = rnf m `seq` rnf i `seq` ()
   {-# NOINLINE rnf #-}
 
 instance Show Bit where
-  show (Bit b) =
+  show (Bit 0 b) =
     case b of
       0 -> "0"
       _ -> "1"
+  show (Bit _ _) = "."
 
 instance ShowX Bit where
   showsPrecX = showsPrecXWith showsPrec
 
 instance Lift Bit where
-  lift (Bit i) = if i == 0 then [| low |] else [| high |]
+  lift (Bit m i) = [| fromInteger## m i |]
   {-# NOINLINE lift #-}
 
 instance Eq Bit where
@@ -210,11 +215,11 @@ instance Eq Bit where
   (/=) = neq##
 
 eq## :: Bit -> Bit -> Bool
-eq## (Bit b1) (Bit b2) = b1 == b2
+eq## (Bit _ b1) (Bit _ b2) = b1 == b2
 {-# NOINLINE eq## #-}
 
 neq## :: Bit -> Bit -> Bool
-neq## (Bit b1) (Bit b2) = b1 == b2
+neq## (Bit _ b1) (Bit _ b2) = b1 == b2
 {-# NOINLINE neq## #-}
 
 instance Ord Bit where
@@ -224,17 +229,17 @@ instance Ord Bit where
   (>=) = ge##
 
 lt##,ge##,gt##,le## :: Bit -> Bit -> Bool
-lt## (Bit n) (Bit m) = n < m
+lt## (Bit _ n) (Bit _ m) = n < m
 {-# NOINLINE lt## #-}
-ge## (Bit n) (Bit m) = n >= m
+ge## (Bit _ n) (Bit _ m) = n >= m
 {-# NOINLINE ge## #-}
-gt## (Bit n) (Bit m) = n > m
+gt## (Bit _ n) (Bit _ m) = n > m
 {-# NOINLINE gt## #-}
-le## (Bit n) (Bit m) = n <= m
+le## (Bit _ n) (Bit _ m) = n <= m
 {-# NOINLINE le## #-}
 
 instance Enum Bit where
-  toEnum     = fromInteger## . toInteger
+  toEnum     = fromInteger## 0 . toInteger
   fromEnum b = if eq## b low then 0 else 1
 
 instance Bounded Bit where
@@ -251,10 +256,10 @@ instance Num Bit where
   negate      = complement##
   abs         = id
   signum b    = b
-  fromInteger = fromInteger##
+  fromInteger = fromInteger## 0
 
-fromInteger## :: Integer -> Bit
-fromInteger## i = Bit (i `mod` 2)
+fromInteger## :: Integer -> Integer -> Bit
+fromInteger## m i = Bit (m `mod` 2) (i `mod` 2)
 {-# NOINLINE fromInteger## #-}
 
 instance Real Bit where
@@ -295,38 +300,38 @@ instance FiniteBits Bit where
   countTrailingZeros b = if eq## b low then 1 else 0
 
 and##, or##, xor## :: Bit -> Bit -> Bit
-and## (Bit v1) (Bit v2) = Bit (v1 .&. v2)
+and## (Bit _ v1) (Bit _ v2) = Bit 0 (v1 .&. v2)
 {-# NOINLINE and## #-}
 
-or## (Bit v1) (Bit v2) = Bit (v1 .|. v2)
+or## (Bit _ v1) (Bit _ v2) = Bit 0 (v1 .|. v2)
 {-# NOINLINE or## #-}
 
-xor## (Bit v1) (Bit v2) = Bit (v1 `xor` v2)
+xor## (Bit _ v1) (Bit _ v2) = Bit 0 (v1 `xor` v2)
 {-# NOINLINE xor## #-}
 
 complement## :: Bit -> Bit
-complement## (Bit 0) = Bit 1
-complement## _       = Bit 0
+complement## (Bit _ 0) = Bit 0 1
+complement## _         = Bit 0 0
 {-# NOINLINE complement## #-}
 
 -- *** BitPack
 pack# :: Bit -> BitVector 1
-pack# (Bit b) = BV b
+pack# (Bit m b) = BV m b
 {-# NOINLINE pack# #-}
 
 unpack# :: BitVector 1 -> Bit
-unpack# (BV b) = Bit b
+unpack# (BV m b) = Bit m b
 {-# NOINLINE unpack# #-}
 
 -- * Instances
 instance NFData (BitVector n) where
-  rnf (BV i) = rnf i `seq` ()
+  rnf (BV i m) = rnf i `seq` rnf m `seq` ()
   {-# NOINLINE rnf #-}
   -- NOINLINE is needed so that Clash doesn't trip on the "BitVector ~# Integer"
   -- coercion
 
 instance KnownNat n => Show (BitVector n) where
-  show bv@(BV i) = reverse . underScore . reverse $ showBV (natVal bv) i []
+  show bv@(BV _ i) = reverse . underScore . reverse $ showBV (natVal bv) i []
     where
       showBV 0 _ s = s
       showBV n v s = let (a,b) = divMod v 2
@@ -361,7 +366,7 @@ instance KnownNat n => ShowX (BitVector n) where
 -- >>> $$(bLit (List.replicate 4 '1')) :: BitVector 4
 -- 1111
 bLit :: KnownNat n => String -> Q (TExp (BitVector n))
-bLit s = [|| fromInteger# i' ||]
+bLit s = [|| fromInteger# 0 i' ||]
   where
     i :: Maybe Integer
     i = fmap fst . listToMaybe . (readInt 2 (`elem` "01") digitToInt) $ filter (/= '_') s
@@ -377,11 +382,11 @@ instance Eq (BitVector n) where
 
 {-# NOINLINE eq# #-}
 eq# :: BitVector n -> BitVector n -> Bool
-eq# (BV v1) (BV v2) = v1 == v2
+eq# (BV _ v1) (BV _ v2 ) = v1 == v2
 
 {-# NOINLINE neq# #-}
 neq# :: BitVector n -> BitVector n -> Bool
-neq# (BV v1) (BV v2) = v1 /= v2
+neq# (BV _ v1) (BV _ v2) = v1 /= v2
 
 instance Ord (BitVector n) where
   (<)  = lt#
@@ -391,20 +396,20 @@ instance Ord (BitVector n) where
 
 lt#,ge#,gt#,le# :: BitVector n -> BitVector n -> Bool
 {-# NOINLINE lt# #-}
-lt# (BV n) (BV m) = n < m
+lt# (BV _ n) (BV _ m) = n < m
 {-# NOINLINE ge# #-}
-ge# (BV n) (BV m) = n >= m
+ge# (BV _ n) (BV _ m) = n >= m
 {-# NOINLINE gt# #-}
-gt# (BV n) (BV m) = n > m
+gt# (BV _ n) (BV _ m) = n > m
 {-# NOINLINE le# #-}
-le# (BV n) (BV m) = n <= m
+le# (BV _ n) (BV _ m) = n <= m
 
 -- | The functions: 'enumFrom', 'enumFromThen', 'enumFromTo', and
 -- 'enumFromThenTo', are not synthesisable.
 instance KnownNat n => Enum (BitVector n) where
-  succ           = (+# fromInteger# 1)
-  pred           = (-# fromInteger# 1)
-  toEnum         = fromInteger# . toInteger
+  succ           = (+# fromInteger# 0 1)
+  pred           = (-# fromInteger# 0 1)
+  toEnum         = fromInteger# 0 . toInteger
   fromEnum       = fromEnum . toInteger#
   enumFrom       = enumFrom#
   enumFromThen   = enumFromThen#
@@ -419,10 +424,10 @@ enumFrom#       :: KnownNat n => BitVector n -> [BitVector n]
 enumFromThen#   :: KnownNat n => BitVector n -> BitVector n -> [BitVector n]
 enumFromTo#     :: BitVector n -> BitVector n -> [BitVector n]
 enumFromThenTo# :: BitVector n -> BitVector n -> BitVector n -> [BitVector n]
-enumFrom# x             = map fromInteger_INLINE [unsafeToInteger x ..]
-enumFromThen# x y       = map fromInteger_INLINE [unsafeToInteger x, unsafeToInteger y ..]
-enumFromTo# x y         = map BV [unsafeToInteger x .. unsafeToInteger y]
-enumFromThenTo# x1 x2 y = map BV [unsafeToInteger x1, unsafeToInteger x2 .. unsafeToInteger y]
+enumFrom# x             = map (fromInteger_INLINE 0) [unsafeToInteger x ..]
+enumFromThen# x y       = map (fromInteger_INLINE 0) [unsafeToInteger x, unsafeToInteger y ..]
+enumFromTo# x y         = map (BV 0) [unsafeToInteger x .. unsafeToInteger y]
+enumFromThenTo# x1 x2 y = map (BV 0) [unsafeToInteger x1, unsafeToInteger x2 .. unsafeToInteger y]
 
 instance KnownNat n => Bounded (BitVector n) where
   minBound = minBound#
@@ -430,12 +435,12 @@ instance KnownNat n => Bounded (BitVector n) where
 
 {-# NOINLINE minBound# #-}
 minBound# :: BitVector n
-minBound# = BV 0
+minBound# = BV 0 0
 
 {-# NOINLINE maxBound# #-}
 maxBound# :: forall n . KnownNat n => BitVector n
 maxBound# = let m = 1 `shiftL` fromInteger (natVal (Proxy @n))
-            in  BV (m-1)
+            in  BV 0 (m-1)
 
 instance KnownNat n => Num (BitVector n) where
   (+)         = (+#)
@@ -444,36 +449,38 @@ instance KnownNat n => Num (BitVector n) where
   negate      = negate#
   abs         = id
   signum bv   = resize# (pack# (reduceOr# bv))
-  fromInteger = fromInteger#
+  fromInteger = fromInteger# 0
 
 (+#),(-#),(*#) :: forall n . KnownNat n => BitVector n -> BitVector n -> BitVector n
 {-# NOINLINE (+#) #-}
-(+#) (BV i) (BV j) = let m = 1 `shiftL` fromInteger (natVal (Proxy @n))
-                         z = i + j
-                     in  if z >= m then BV (z - m) else BV z
+(+#) (BV _ i) (BV _ j) =
+  let m = 1 `shiftL` fromInteger (natVal (Proxy @n))
+      z = i + j
+  in  if z >= m then BV 0 (z - m) else BV 0 z
 
 {-# NOINLINE (-#) #-}
-(-#) (BV i) (BV j) = let m = 1 `shiftL` fromInteger (natVal (Proxy @n))
-                         z = i - j
-                     in  if z < 0 then BV (m + z) else BV z
+(-#) (BV _ i) (BV _ j) =
+  let m = 1 `shiftL` fromInteger (natVal (Proxy @n))
+      z = i - j
+  in  if z < 0 then BV 0 (m + z) else BV 0 z
 
 {-# NOINLINE (*#) #-}
-(*#) (BV i) (BV j) = fromInteger_INLINE (i * j)
+(*#) (BV _ i) (BV _ j) = fromInteger_INLINE 0 (i * j)
 
 {-# NOINLINE negate# #-}
 negate# :: forall n . KnownNat n => BitVector n -> BitVector n
-negate# (BV 0) = BV 0
-negate# (BV i) = BV (sz - i)
+negate# (BV _ 0) = BV 0 0
+negate# (BV _ i) = BV 0 (sz - i)
   where
     sz = 1 `shiftL` fromInteger (natVal (Proxy @n))
 
 {-# NOINLINE fromInteger# #-}
-fromInteger# :: KnownNat n => Integer -> BitVector n
+fromInteger# :: KnownNat n => Integer -> Integer -> BitVector n
 fromInteger# = fromInteger_INLINE
 
 {-# INLINE fromInteger_INLINE #-}
-fromInteger_INLINE :: forall n . KnownNat n => Integer -> BitVector n
-fromInteger_INLINE i = sz `seq` BV (i `mod` sz)
+fromInteger_INLINE :: forall n . KnownNat n => Integer -> Integer -> BitVector n
+fromInteger_INLINE m i = sz `seq` BV (m `mod` sz) (i `mod` sz)
   where
     sz = 1 `shiftL` fromInteger (natVal (Proxy @n))
 
@@ -486,20 +493,20 @@ instance (KnownNat m, KnownNat n) => ExtendingNum (BitVector m) (BitVector n) wh
 
 {-# NOINLINE plus# #-}
 plus# :: BitVector m -> BitVector n -> BitVector (Max m n + 1)
-plus# (BV a) (BV b) = BV (a + b)
+plus# (BV _ a) (BV _ b) = BV 0 (a + b)
 
 {-# NOINLINE minus# #-}
 minus# :: forall m n . (KnownNat m, KnownNat n) => BitVector m -> BitVector n
                                                 -> BitVector (Max m n + 1)
-minus# (BV a) (BV b) =
+minus# (BV _ a) (BV _ b) =
   let sz   = fromInteger (natVal (Proxy @(Max m n + 1)))
       mask = 1 `shiftL` sz
       z    = a - b
-  in  if z < 0 then BV (mask + z) else BV z
+  in  if z < 0 then BV 0 (mask + z) else BV 0 z
 
 {-# NOINLINE times# #-}
 times# :: BitVector m -> BitVector n -> BitVector (m + n)
-times# (BV a) (BV b) = BV (a * b)
+times# (BV _ a) (BV _ b) = BV 0 (a * b)
 
 instance KnownNat n => Real (BitVector n) where
   toRational = toRational . toInteger#
@@ -515,13 +522,13 @@ instance KnownNat n => Integral (BitVector n) where
 
 quot#,rem# :: BitVector n -> BitVector n -> BitVector n
 {-# NOINLINE quot# #-}
-quot# (BV i) (BV j) = BV (i `quot` j)
+quot# (BV _ i) (BV _ j) = BV 0 (i `quot` j)
 {-# NOINLINE rem# #-}
-rem# (BV i) (BV j) = BV (i `rem` j)
+rem# (BV _ i) (BV _ j) = BV 0 (i `rem` j)
 
 {-# NOINLINE toInteger# #-}
 toInteger# :: BitVector n -> Integer
-toInteger# (BV i) = i
+toInteger# (BV _ i) = i
 
 instance KnownNat n => Bits (BitVector n) where
   (.&.)             = and#
@@ -558,7 +565,7 @@ countTrailingZerosBV = V.foldl (\l r -> if eq## r low then 1 + l else 0) 0 . V.b
 
 {-# NOINLINE reduceAnd# #-}
 reduceAnd# :: KnownNat n => BitVector n -> Bit
-reduceAnd# bv@(BV i) = Bit (smallInteger (dataToTag# check))
+reduceAnd# bv@(BV _ i) = Bit 0 (smallInteger (dataToTag# check))
   where
     check = i == maxI
 
@@ -567,13 +574,13 @@ reduceAnd# bv@(BV i) = Bit (smallInteger (dataToTag# check))
 
 {-# NOINLINE reduceOr# #-}
 reduceOr# :: BitVector n -> Bit
-reduceOr# (BV i) = Bit (smallInteger (dataToTag# check))
+reduceOr# (BV _ i) = Bit 0 (smallInteger (dataToTag# check))
   where
     check = i /= 0
 
 {-# NOINLINE reduceXor# #-}
 reduceXor# :: BitVector n -> Bit
-reduceXor# (BV i) = Bit (toInteger (popCount i `mod` 2))
+reduceXor# (BV _ i) = Bit 0 (toInteger (popCount i `mod` 2))
 
 instance Default (BitVector n) where
   def = minBound#
@@ -591,8 +598,9 @@ maxIndex# bv = fromInteger (natVal bv) - 1
 -- ** Indexing
 {-# NOINLINE index# #-}
 index# :: KnownNat n => BitVector n -> Int -> Bit
-index# bv@(BV v) i
-    | i >= 0 && i < sz = Bit (smallInteger
+index# bv@(BV _ v) i
+    | i >= 0 && i < sz = Bit 0
+                             (smallInteger
                              (dataToTag#
                              (testBit v i)))
     | otherwise        = err
@@ -608,18 +616,18 @@ index# bv@(BV v) i
 {-# NOINLINE msb# #-}
 -- | MSB
 msb# :: forall n . KnownNat n => BitVector n -> Bit
-msb# (BV v)
+msb# (BV _ v)
   = let i = fromInteger (natVal (Proxy @n) - 1)
-    in  Bit (smallInteger (dataToTag# (testBit v i)))
+    in  Bit 0 (smallInteger (dataToTag# (testBit v i)))
 
 {-# NOINLINE lsb# #-}
 -- | LSB
 lsb# :: BitVector n -> Bit
-lsb# (BV v) = Bit (smallInteger (dataToTag# (testBit v 0)))
+lsb# (BV _ v) = Bit 0 (smallInteger (dataToTag# (testBit v 0)))
 
 {-# NOINLINE slice# #-}
 slice# :: BitVector (m + 1 + i) -> SNat m -> SNat n -> BitVector (m + 1 - n)
-slice# (BV i) m n = BV (shiftR (i .&. mask) n')
+slice# (BV _ i) m n = BV 0 (shiftR (i .&. mask) n')
   where
     m' = snatToInteger m
     n' = snatToNum n
@@ -632,15 +640,15 @@ slice# (BV i) m n = BV (shiftR (i .&. mask) n')
 {-# NOINLINE (++#) #-}
 -- | Concatenate two 'BitVector's
 (++#) :: KnownNat m => BitVector n -> BitVector m -> BitVector (n + m)
-(BV v1) ++# bv2@(BV v2) = BV (v1' + v2)
+(BV _ v1) ++# bv2@(BV _ v2) = BV 0 (v1' + v2)
   where
     v1' = shiftL v1 (fromInteger (natVal bv2))
 
 -- * Modifying BitVectors
 {-# NOINLINE replaceBit# #-}
 replaceBit# :: KnownNat n => BitVector n -> Int -> Bit -> BitVector n
-replaceBit# bv@(BV v) i (Bit b)
-    | i >= 0 && i < sz = BV (if b == 1 then setBit v i else clearBit v i)
+replaceBit# bv@(BV _ v) i (Bit _ b)
+    | i >= 0 && i < sz = BV 0 (if b == 1 then setBit v i else clearBit v i)
     | otherwise        = err
   where
     sz   = fromInteger (natVal bv)
@@ -654,7 +662,7 @@ replaceBit# bv@(BV v) i (Bit b)
 {-# NOINLINE setSlice# #-}
 setSlice# :: BitVector (m + 1 + i) -> SNat m -> SNat n -> BitVector (m + 1 - n)
           -> BitVector (m + 1 + i)
-setSlice# (BV i) m n (BV j) = BV ((i .&. mask) .|. j')
+setSlice# (BV _ i) m n (BV _ j) = BV 0 ((i .&. mask) .|. j')
   where
     m' = snatToInteger m
     n' = snatToInteger n
@@ -665,7 +673,7 @@ setSlice# (BV i) m n (BV j) = BV ((i .&. mask) .|. j')
 {-# NOINLINE split# #-}
 split# :: forall n m . KnownNat n
        => BitVector (m + n) -> (BitVector m, BitVector n)
-split# (BV i) = (BV l, BV r)
+split# (BV _ i) = (BV 0 l, BV 0 r)
   where
     n     = fromInteger (natVal (Proxy @n))
     mask  = 1 `shiftL` n
@@ -676,36 +684,36 @@ split# (BV i) = (BV l, BV r)
 
 and#, or#, xor# :: BitVector n -> BitVector n -> BitVector n
 {-# NOINLINE and# #-}
-and# (BV v1) (BV v2) = BV (v1 .&. v2)
+and# (BV _ v1) (BV _ v2) = BV 0 (v1 .&. v2)
 
 {-# NOINLINE or# #-}
-or# (BV v1) (BV v2) = BV (v1 .|. v2)
+or# (BV _ v1) (BV _ v2) = BV 0 (v1 .|. v2)
 
 {-# NOINLINE xor# #-}
-xor# (BV v1) (BV v2) = BV (v1 `xor` v2)
+xor# (BV _ v1) (BV _ v2) = BV 0 (v1 `xor` v2)
 
 {-# NOINLINE complement# #-}
 complement# :: KnownNat n => BitVector n -> BitVector n
-complement# (BV v1) = fromInteger_INLINE (complement v1)
+complement# (BV _ v1) = fromInteger_INLINE 0 (complement v1)
 
 shiftL#, shiftR#, rotateL#, rotateR#
   :: KnownNat n => BitVector n -> Int -> BitVector n
 
 {-# NOINLINE shiftL# #-}
-shiftL# (BV v) i
+shiftL# (BV _ v) i
   | i < 0     = error
               $ "'shiftL undefined for negative number: " ++ show i
-  | otherwise = fromInteger_INLINE (shiftL v i)
+  | otherwise = fromInteger_INLINE 0 (shiftL v i)
 
 {-# NOINLINE shiftR# #-}
-shiftR# (BV v) i
+shiftR# (BV _ v) i
   | i < 0     = error
               $ "'shiftR undefined for negative number: " ++ show i
-  | otherwise = BV (shiftR v i)
+  | otherwise = BV 0 (shiftR v i)
 
 {-# NOINLINE rotateL# #-}
-rotateL# _ b | b < 0 = error "'shiftL undefined for negative numbers"
-rotateL# bv@(BV n) b   = fromInteger_INLINE (l .|. r)
+rotateL# _ b | b < 0   = error "'shiftL undefined for negative numbers"
+rotateL# bv@(BV _ n) b = fromInteger_INLINE 0 (l .|. r)
   where
     l    = shiftL n b'
     r    = shiftR n b''
@@ -715,8 +723,8 @@ rotateL# bv@(BV n) b   = fromInteger_INLINE (l .|. r)
     sz   = fromInteger (natVal bv)
 
 {-# NOINLINE rotateR# #-}
-rotateR# _ b | b < 0 = error "'shiftR undefined for negative numbers"
-rotateR# bv@(BV n) b   = fromInteger_INLINE (l .|. r)
+rotateR# _ b | b < 0   = error "'shiftR undefined for negative numbers"
+rotateR# bv@(BV _ n) b = fromInteger_INLINE 0 (l .|. r)
   where
     l   = shiftR n b'
     r   = shiftL n b''
@@ -739,11 +747,12 @@ instance Resize BitVector where
 
 {-# NOINLINE resize# #-}
 resize# :: forall n m . KnownNat m => BitVector n -> BitVector m
-resize# (BV i) = let m = 1 `shiftL` fromInteger (natVal (Proxy @m))
-                 in  if i >= m then fromInteger_INLINE i else BV i
+resize# (BV _ i) =
+  let m = 1 `shiftL` fromInteger (natVal (Proxy @m))
+  in  if i >= m then fromInteger_INLINE 0 i else BV 0 i
 
 instance KnownNat n => Lift (BitVector n) where
-  lift bv@(BV i) = sigE [| fromInteger# i |] (decBitVector (natVal bv))
+  lift bv@(BV m i) = sigE [| fromInteger# m i |] (decBitVector (natVal bv))
   {-# NOINLINE lift #-}
 
 decBitVector :: Integer -> TypeQ

--- a/src/Clash/Sized/Internal/BitVector.hs-boot
+++ b/src/Clash/Sized/Internal/BitVector.hs-boot
@@ -9,8 +9,11 @@ Maintainer :  Christiaan Baaij <christiaan.baaij@gmail.com>
 {-# LANGUAGE RoleAnnotations #-}
 module Clash.Sized.Internal.BitVector where
 
-import GHC.TypeLits (Nat)
+import GHC.TypeLits (KnownNat,Nat)
+import GHC.Stack    (HasCallStack)
 
 type role BitVector phantom
 data BitVector :: Nat -> *
 data Bit
+
+undefError :: (HasCallStack, KnownNat n) => String -> [BitVector n] -> a

--- a/src/Clash/Sized/Internal/Index.hs
+++ b/src/Clash/Sized/Internal/Index.hs
@@ -140,11 +140,11 @@ fromSNat = snatToNum
 
 {-# NOINLINE pack# #-}
 pack# :: Index n -> BitVector (CLog 2 n)
-pack# (I i) = BV i
+pack# (I i) = BV 0 i
 
 {-# NOINLINE unpack# #-}
 unpack# :: KnownNat n => BitVector (CLog 2 n) -> Index n
-unpack# (BV i) = fromInteger_INLINE i
+unpack# (BV _ i) = fromInteger_INLINE i
 
 instance Eq (Index n) where
   (==) = eq#

--- a/src/Clash/Sized/Internal/Signed.hs
+++ b/src/Clash/Sized/Internal/Signed.hs
@@ -105,7 +105,7 @@ import Clash.Class.Num                (ExtendingNum (..), SaturatingNum (..),
 import Clash.Class.Resize             (Resize (..))
 import Clash.Prelude.BitIndex         ((!), msb, replaceBit, split)
 import Clash.Prelude.BitReduction     (reduceAnd, reduceOr)
-import Clash.Sized.Internal.BitVector (BitVector (BV), Bit, (++#), high, low)
+import Clash.Sized.Internal.BitVector (BitVector (BV), Bit, (++#), high, low, undefError)
 import qualified Clash.Sized.Internal.BitVector as BV
 import Clash.XException               (ShowX (..), Undefined, showsPrecXWith)
 
@@ -183,9 +183,10 @@ pack# (S i) = let m = 1 `shiftL` fromInteger (natVal (Proxy @n))
 
 {-# NOINLINE unpack# #-}
 unpack# :: forall n . KnownNat n => BitVector n -> Signed n
-unpack# (BV _ i) =
+unpack# (BV 0 i) =
   let m = 1 `shiftL` fromInteger (natVal (Proxy @n) - 1)
   in  if i >= m then S (i-2*m) else S i
+unpack# bv = undefError "Signed.unpack" [bv]
 
 instance Eq (Signed n) where
   (==) = eq#

--- a/src/Clash/Sized/Internal/Signed.hs
+++ b/src/Clash/Sized/Internal/Signed.hs
@@ -179,11 +179,11 @@ instance KnownNat n => BitPack (Signed n) where
 {-# NOINLINE pack# #-}
 pack# :: forall n . KnownNat n => Signed n -> BitVector n
 pack# (S i) = let m = 1 `shiftL` fromInteger (natVal (Proxy @n))
-              in  if i < 0 then BV (m + i) else BV i
+              in  if i < 0 then BV 0 (m + i) else BV 0 i
 
 {-# NOINLINE unpack# #-}
 unpack# :: forall n . KnownNat n => BitVector n -> Signed n
-unpack# (BV i) =
+unpack# (BV _ i) =
   let m = 1 `shiftL` fromInteger (natVal (Proxy @n) - 1)
   in  if i >= m then S (i-2*m) else S i
 

--- a/src/Clash/Sized/Internal/Unsigned.hs
+++ b/src/Clash/Sized/Internal/Unsigned.hs
@@ -167,11 +167,11 @@ instance BitPack (Unsigned n) where
 
 {-# NOINLINE pack# #-}
 pack# :: Unsigned n -> BitVector n
-pack# (U i) = BV i
+pack# (U i) = BV 0 i
 
 {-# NOINLINE unpack# #-}
 unpack# :: BitVector n -> Unsigned n
-unpack# (BV i) = U i
+unpack# (BV _ i) = U i
 
 instance Eq (Unsigned n) where
   (==) = eq#

--- a/src/Clash/Sized/Internal/Unsigned.hs
+++ b/src/Clash/Sized/Internal/Unsigned.hs
@@ -98,7 +98,7 @@ import Clash.Class.Num                (ExtendingNum (..), SaturatingNum (..),
 import Clash.Class.Resize             (Resize (..))
 import Clash.Prelude.BitIndex         ((!), msb, replaceBit, split)
 import Clash.Prelude.BitReduction     (reduceOr)
-import Clash.Sized.Internal.BitVector (BitVector (BV), Bit, high, low)
+import Clash.Sized.Internal.BitVector (BitVector (BV), Bit, high, low, undefError)
 import qualified Clash.Sized.Internal.BitVector as BV
 import Clash.XException               (ShowX (..), Undefined, showsPrecXWith)
 
@@ -160,7 +160,7 @@ instance ShowX (Unsigned n) where
 instance KnownNat n => Read (Unsigned n) where
   readPrec = fromIntegral <$> (readPrec :: ReadPrec Natural)
 
-instance BitPack (Unsigned n) where
+instance KnownNat n => BitPack (Unsigned n) where
   type BitSize (Unsigned n) = n
   pack   = pack#
   unpack = unpack#
@@ -170,8 +170,9 @@ pack# :: Unsigned n -> BitVector n
 pack# (U i) = BV 0 i
 
 {-# NOINLINE unpack# #-}
-unpack# :: BitVector n -> Unsigned n
-unpack# (BV _ i) = U i
+unpack# :: KnownNat n => BitVector n -> Unsigned n
+unpack# (BV 0 i) = U i
+unpack# bv = undefError "Unsigned.unpack" [bv]
 
 instance Eq (Unsigned n) where
   (==) = eq#

--- a/tests/Clash/Tests/DerivingDataRepr.hs
+++ b/tests/Clash/Tests/DerivingDataRepr.hs
@@ -1,0 +1,95 @@
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE BinaryLiterals #-}
+
+module Clash.Tests.DerivingDataRepr where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+import Prelude ((=<<), ($))
+import Clash.Annotations.BitRepresentation
+import Clash.Annotations.BitRepresentation.Deriving
+import Clash.Tests.DerivingDataReprTrain (Train(..))
+
+oneHotOverlapRepr :: DataReprAnn
+oneHotOverlapRepr = $( (simpleDerivator OneHot Overlap) =<< [t| Train |] )
+
+oneHotOverlapRepr' :: DataReprAnn
+oneHotOverlapRepr' =
+  DataReprAnn
+    $(reprType [t| Train |])
+    8
+    [ ConstrRepr 'Passenger   16  16  [0b1100]
+    , ConstrRepr 'Freight     32  32  [0b1100, 0b0011]
+    , ConstrRepr 'Maintenance 64  64  []
+    , ConstrRepr 'Toy         128 128 []
+    ]
+
+oneHotWideRepr :: DataReprAnn
+oneHotWideRepr = $( (simpleDerivator OneHot Wide) =<< [t| Train |] )
+
+oneHotWideRepr' :: DataReprAnn
+oneHotWideRepr' =
+  DataReprAnn
+    $(reprType [t| Train |])
+    10
+    [ ConstrRepr 'Passenger   64  64  [0b110000]
+    , ConstrRepr 'Freight     128 128 [0b001100, 0b000011]
+    , ConstrRepr 'Maintenance 256 256 []
+    , ConstrRepr 'Toy         512 512 []
+    ]
+
+countOverlapRepr :: DataReprAnn
+countOverlapRepr = $( (simpleDerivator Binary Overlap) =<< [t| Train |] )
+
+countOverlapRepr' :: DataReprAnn
+countOverlapRepr' =
+  DataReprAnn
+    $(reprType [t| Train |])
+    6
+    [ ConstrRepr 'Passenger   0b110000 0b000000 [0b001100]
+    , ConstrRepr 'Freight     0b110000 0b010000 [0b001100,0b000011]
+    , ConstrRepr 'Maintenance 0b110000 0b100000 []
+    , ConstrRepr 'Toy         0b110000 0b110000 []
+    ]
+
+countWideRepr :: DataReprAnn
+countWideRepr = $( (simpleDerivator Binary Wide) =<< [t| Train |] )
+
+countWideRepr' :: DataReprAnn
+countWideRepr' =
+  DataReprAnn
+    $(reprType [t| Train |])
+    8
+    [ ConstrRepr 'Passenger   0b11000000 0b00000000 [0b110000]
+    , ConstrRepr 'Freight     0b11000000 0b01000000 [0b001100,0b000011]
+    , ConstrRepr 'Maintenance 0b11000000 0b10000000 []
+    , ConstrRepr 'Toy         0b11000000 0b11000000 []
+    ]
+
+packedRepr :: DataReprAnn
+packedRepr = $( packedDerivator =<< [t| Train |] )
+
+packedRepr' :: DataReprAnn
+packedRepr' =
+  DataReprAnn
+    $(reprType [t| Train |])
+    5
+    [ ConstrRepr 'Freight     0b10000 0 [12,3]
+    , ConstrRepr 'Passenger   3       1 [12]
+    , ConstrRepr 'Toy         3       2 []
+    , ConstrRepr 'Maintenance 3       3 []
+    ]
+
+tests :: TestTree
+tests = testGroup "DerivingDataRepr"
+  [ testCase "OneHotOverlap" $ oneHotOverlapRepr @?= oneHotOverlapRepr'
+  , testCase "OneHotWide"    $ oneHotWideRepr    @?= oneHotWideRepr'
+  , testCase "BinaryOverlap" $ countOverlapRepr  @?= countOverlapRepr'
+  , testCase "BinaryWide"    $ countWideRepr     @?= countWideRepr'
+  , testCase "Packed"        $ packedRepr        @?= packedRepr'
+  ]

--- a/tests/Clash/Tests/DerivingDataRepr.hs
+++ b/tests/Clash/Tests/DerivingDataRepr.hs
@@ -13,8 +13,12 @@ import Test.Tasty.HUnit
 import Prelude ((=<<), ($))
 import Clash.Annotations.BitRepresentation
 import Clash.Annotations.BitRepresentation.Deriving
-import Clash.Tests.DerivingDataReprTrain (Train(..))
+import Clash.Tests.DerivingDataReprTypes (Train(..), RGB(..))
+import Data.Maybe (Maybe(..))
 
+---------------------------------------------------------
+------------ DERIVING SIMPLE REPRESENTATIONS ------------
+---------------------------------------------------------
 oneHotOverlapRepr :: DataReprAnn
 oneHotOverlapRepr = $( (simpleDerivator OneHot Overlap) =<< [t| Train |] )
 
@@ -71,6 +75,10 @@ countWideRepr' =
     , ConstrRepr 'Toy         0b11000000 0b11000000 []
     ]
 
+------------------------------------------------
+------------ PACKED REPRESENTATIONS ------------
+------------------------------------------------
+
 packedRepr :: DataReprAnn
 packedRepr = $( packedDerivator =<< [t| Train |] )
 
@@ -85,6 +93,23 @@ packedRepr' =
     , ConstrRepr 'Maintenance 3       3 []
     ]
 
+------------------------------------------------------
+------------ PACKED MAYBE REPRESENTATIONS ------------
+------------------------------------------------------
+
+packedMaybeRGB :: DataReprAnn
+packedMaybeRGB = $( packedMaybeDerivator $(defaultDerivator =<< [t| Maybe RGB |]) =<< [t| Maybe RGB |] )
+
+packedMaybeRGB' :: DataReprAnn
+packedMaybeRGB' =
+  DataReprAnn
+    $(reprType [t| Maybe RGB |])
+    2
+    [ ConstrRepr 'Nothing 0b11 0b11 []
+    , ConstrRepr 'Just    0b00 0b00 [0b11]
+    ]
+
+-- MAIN
 tests :: TestTree
 tests = testGroup "DerivingDataRepr"
   [ testCase "OneHotOverlap" $ oneHotOverlapRepr @?= oneHotOverlapRepr'
@@ -92,4 +117,5 @@ tests = testGroup "DerivingDataRepr"
   , testCase "BinaryOverlap" $ countOverlapRepr  @?= countOverlapRepr'
   , testCase "BinaryWide"    $ countWideRepr     @?= countWideRepr'
   , testCase "Packed"        $ packedRepr        @?= packedRepr'
+  , testCase "PackedMaybe"   $ packedMaybeRGB    @?= packedMaybeRGB'
   ]

--- a/tests/Clash/Tests/DerivingDataRepr.hs
+++ b/tests/Clash/Tests/DerivingDataRepr.hs
@@ -25,7 +25,7 @@ oneHotOverlapRepr = $( (simpleDerivator OneHot Overlap) =<< [t| Train |] )
 oneHotOverlapRepr' :: DataReprAnn
 oneHotOverlapRepr' =
   DataReprAnn
-    $(reprType [t| Train |])
+    $(liftQ [t| Train |])
     8
     [ ConstrRepr 'Passenger   16  16  [0b1100]
     , ConstrRepr 'Freight     32  32  [0b1100, 0b0011]
@@ -39,7 +39,7 @@ oneHotWideRepr = $( (simpleDerivator OneHot Wide) =<< [t| Train |] )
 oneHotWideRepr' :: DataReprAnn
 oneHotWideRepr' =
   DataReprAnn
-    $(reprType [t| Train |])
+    $(liftQ [t| Train |])
     10
     [ ConstrRepr 'Passenger   64  64  [0b110000]
     , ConstrRepr 'Freight     128 128 [0b001100, 0b000011]
@@ -53,7 +53,7 @@ countOverlapRepr = $( (simpleDerivator Binary Overlap) =<< [t| Train |] )
 countOverlapRepr' :: DataReprAnn
 countOverlapRepr' =
   DataReprAnn
-    $(reprType [t| Train |])
+    $(liftQ [t| Train |])
     6
     [ ConstrRepr 'Passenger   0b110000 0b000000 [0b001100]
     , ConstrRepr 'Freight     0b110000 0b010000 [0b001100,0b000011]
@@ -67,7 +67,7 @@ countWideRepr = $( (simpleDerivator Binary Wide) =<< [t| Train |] )
 countWideRepr' :: DataReprAnn
 countWideRepr' =
   DataReprAnn
-    $(reprType [t| Train |])
+    $(liftQ [t| Train |])
     8
     [ ConstrRepr 'Passenger   0b11000000 0b00000000 [0b110000]
     , ConstrRepr 'Freight     0b11000000 0b01000000 [0b001100,0b000011]
@@ -85,7 +85,7 @@ packedRepr = $( packedDerivator =<< [t| Train |] )
 packedRepr' :: DataReprAnn
 packedRepr' =
   DataReprAnn
-    $(reprType [t| Train |])
+    $(liftQ [t| Train |])
     5
     [ ConstrRepr 'Freight     0b10000 0 [12,3]
     , ConstrRepr 'Passenger   3       1 [12]
@@ -103,7 +103,7 @@ packedMaybeRGB = $( packedMaybeDerivator $(defaultDerivator =<< [t| Maybe RGB |]
 packedMaybeRGB' :: DataReprAnn
 packedMaybeRGB' =
   DataReprAnn
-    $(reprType [t| Maybe RGB |])
+    $(liftQ [t| Maybe RGB |])
     2
     [ ConstrRepr 'Nothing 0b11 0b11 []
     , ConstrRepr 'Just    0b00 0b00 [0b11]

--- a/tests/Clash/Tests/DerivingDataReprTrain.hs
+++ b/tests/Clash/Tests/DerivingDataReprTrain.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Clash.Tests.DerivingDataReprTrain where
+
+import Clash.Sized.Unsigned
+
+type SmallInt = Unsigned 2
+
+data Train
+  = Passenger
+      SmallInt
+      -- ^ Number of wagons
+  | Freight
+      SmallInt
+      -- ^ Number of wagons
+      SmallInt
+      -- ^ Max weight
+  | Maintenance
+  | Toy

--- a/tests/Clash/Tests/DerivingDataReprTypes.hs
+++ b/tests/Clash/Tests/DerivingDataReprTypes.hs
@@ -4,20 +4,30 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeFamilies #-}
 
-module Clash.Tests.DerivingDataReprTrain where
+module Clash.Tests.DerivingDataReprTypes where
 
 import Clash.Sized.Unsigned
+import Clash.Annotations.BitRepresentation.Deriving
 
 type SmallInt = Unsigned 2
 
 data Train
   = Passenger
+      -- Number of wagons:
       SmallInt
-      -- ^ Number of wagons
   | Freight
+      -- Number of wagons:
       SmallInt
-      -- ^ Number of wagons
+      -- Max weight:
       SmallInt
-      -- ^ Max weight
   | Maintenance
   | Toy
+
+
+data RGB
+  = R
+  | G
+  | B
+
+deriveDefaultAnnotation [t| RGB |]
+deriveBitPack [t| RGB |]

--- a/tests/unittests.hs
+++ b/tests/unittests.hs
@@ -1,0 +1,13 @@
+module Main where
+
+import Test.Tasty
+
+import qualified Clash.Tests.DerivingDataRepr
+
+tests :: TestTree
+tests = testGroup "Unittests"
+  [ Clash.Tests.DerivingDataRepr.tests
+  ]
+
+main :: IO ()
+main = defaultMain tests


### PR DESCRIPTION
Annotation for custom bit representations of data types

Using `ANN` pragma's you can tell the Clash compiler to use a custom bit-representation for a data type.

For example:

```haskell
data Color = R | G | B
{-# ANN module (DataReprAnn
                  $(liftQ [t|Color|])
                  2
                  [ ConstrRepr 'R 0b11 0b00 []
                  , ConstrRepr 'G 0b11 0b01 []
                  , ConstrRepr 'B 0b11 0b10 []
                  ]) #-}
```

This specifies that `R` should be encoded as `0b00`, `G` as `0b01`, and B as `0b10`. The first binary value in every ConstRepr in this example is a mask, indicating which bits in the data type are relevant. In this case all of the bits are.

Or if we want to annotate `Maybe Color`:

```haskell
{-# ANN module ( DataReprAnn
                   $(liftQ [t|Maybe Color|])
                   2
                   [ ConstRepr 'Nothing 0b11 0b11 []
                   , ConstRepr 'Just 0b00 0b00 [0b11]
                   ] ) #-}
```

By default, `Maybe Color` is a data type which consumes 3 bits. A single bit to indicate the constructor (either `Just` or `Nothing`), and two bits to encode the first field of `Just`. Notice that we saved a single bit, by exploiting the fact that `Color` only uses three values (0, 1, 2), but takes two bits to encode it. We can therefore use the last - unused - value (3), to encode one of the constructors of Maybe. We indicate which bits encode the underlying `Color` by passing `[0b11]` to `ConstRepr`. This indicates that the first field is encoded in the first and second bit of the whole datatype (0b11).

Additionally contains:

* Template Haskell functions to derive `BitPack` instances for annotated types
* Template Haskell functions to derive representations: e.g. one-hot or binary encodings for enum types, and wide (non-overlapping fields) for sum tupes.