### PR TITLE
Rename plus/minus/mult to add/sub/mul

### DIFF
--- a/benchmarks/BenchBitVector.hs
+++ b/benchmarks/BenchBitVector.hs
@@ -70,21 +70,21 @@ timesBench = env setup $ \m ->
   where
     setup = return (smallValue1,smallValue2)
 
-boundedPlusBench :: Benchmark
-boundedPlusBench = env setup $ \m ->
-  bench "boundedPlus WORD_SIZE_IN_BITS" $ nf (uncurry (boundedPlus)) m
+boundedAddBench :: Benchmark
+boundedAddBench = env setup $ \m ->
+  bench "boundedAdd WORD_SIZE_IN_BITS" $ nf (uncurry (boundedAdd)) m
   where
     setup = return (smallValue1,smallValue2)
 
-boundedMinBench :: Benchmark
-boundedMinBench = env setup $ \m ->
-  bench "boundedMin WORD_SIZE_IN_BITS" $ nf (uncurry (boundedMin)) m
+boundedSubBench :: Benchmark
+boundedSubBench = env setup $ \m ->
+  bench "boundedSub WORD_SIZE_IN_BITS" $ nf (uncurry (boundedSub)) m
   where
     setup = return (smallValue1,smallValue2)
 
-boundedMultBench :: Benchmark
-boundedMultBench = env setup $ \m ->
-  bench "boundedMult WORD_SIZE_IN_BITS" $ nf (uncurry (boundedMult)) m
+boundedMulBench :: Benchmark
+boundedMulBench = env setup $ \m ->
+  bench "boundedMul WORD_SIZE_IN_BITS" $ nf (uncurry (boundedMul)) m
   where
     setup = return (smallValue1,smallValue2)
 

--- a/benchmarks/BenchFixed.hs
+++ b/benchmarks/BenchFixed.hs
@@ -50,6 +50,6 @@ multBench = env setup $ \m ->
 
 multBench_wrap :: Benchmark
 multBench_wrap = env setup $ \m ->
-  bench "satMult SatWrap" $ nf (uncurry (satMult SatWrap)) m
+  bench "satMult SatWrap" $ nf (uncurry (satMul SatWrap)) m
   where
     setup = return (smallValueU1,smallValueU2)

--- a/benchmarks/benchmark-main.hs
+++ b/benchmarks/benchmark-main.hs
@@ -18,9 +18,9 @@ main =
         , BV.plusBench
         , BV.minusBench
         , BV.timesBench
-        , BV.boundedPlusBench
-        , BV.boundedMinBench
-        , BV.boundedMultBench
+        , BV.boundedAddBench
+        , BV.boundedSubBench
+        , BV.boundedMulBench
         , BV.msbBench
         , BV.msbBenchL
         , BV.appendBench

--- a/src/Clash/Class/Num.hs
+++ b/src/Clash/Class/Num.hs
@@ -18,9 +18,9 @@ module Clash.Class.Num
     -- * Saturating arithmetic functions
   , SaturationMode (..)
   , SaturatingNum (..)
-  , boundedPlus
-  , boundedMin
-  , boundedMult
+  , boundedAdd
+  , boundedSub
+  , boundedMul
   )
 where
 
@@ -32,15 +32,15 @@ class ExtendingNum a b where
   type AResult a b
   -- | Add values of different (sub-)types, return a value of a (sub-)type
   -- that is potentially different from either argument.
-  plus  :: a -> b -> AResult a b
+  add  :: a -> b -> AResult a b
   -- | Subtract values of different (sub-)types, return a value of a (sub-)type
   -- that is potentially different from either argument.
-  minus :: a -> b -> AResult a b
+  sub :: a -> b -> AResult a b
   -- | Type of the result of the multiplication
   type MResult a b
   -- | Multiply values of different (sub-)types, return a value of a (sub-)type
   -- that is potentially different from either argument.
-  times :: a -> b -> MResult a b
+  mul :: a -> b -> MResult a b
 
 -- * Saturating arithmetic functions
 
@@ -59,25 +59,25 @@ data SaturationMode
 -- using 'SaturationMode'.
 class (Bounded a, Num a) => SaturatingNum a where
   -- | Addition with parametrisable over- and underflow behaviour
-  satPlus :: SaturationMode -> a -> a -> a
+  satAdd :: SaturationMode -> a -> a -> a
   -- | Subtraction with parametrisable over- and underflow behaviour
-  satMin  :: SaturationMode -> a -> a -> a
+  satSub  :: SaturationMode -> a -> a -> a
   -- | Multiplication with parametrisable over- and underflow behaviour
-  satMult :: SaturationMode -> a -> a -> a
+  satMul :: SaturationMode -> a -> a -> a
 
-{-# INLINE boundedPlus #-}
+{-# INLINE boundedAdd #-}
 -- | Addition that clips to 'maxBound' on overflow, and 'minBound' on underflow
-boundedPlus :: SaturatingNum a => a -> a -> a
-boundedPlus = satPlus SatBound
+boundedAdd :: SaturatingNum a => a -> a -> a
+boundedAdd = satAdd SatBound
 
-{-# INLINE boundedMin #-}
+{-# INLINE boundedSub #-}
 -- | Subtraction that clips to 'maxBound' on overflow, and 'minBound' on
 -- underflow
-boundedMin  :: SaturatingNum a => a -> a -> a
-boundedMin = satMin SatBound
+boundedSub  :: SaturatingNum a => a -> a -> a
+boundedSub = satSub SatBound
 
-{-# INLINE boundedMult #-}
+{-# INLINE boundedMul #-}
 -- | Multiplication that clips to 'maxBound' on overflow, and 'minBound' on
 -- underflow
-boundedMult :: SaturatingNum a => a -> a -> a
-boundedMult = satMult SatBound
+boundedMul :: SaturatingNum a => a -> a -> a
+boundedMul = satMul SatBound

--- a/src/Clash/Sized/Internal/BitVector.hs
+++ b/src/Clash/Sized/Internal/BitVector.hs
@@ -533,10 +533,10 @@ fromInteger_INLINE m i = sz `seq` BV (m `mod` sz) (i `mod` sz)
 
 instance (KnownNat m, KnownNat n) => ExtendingNum (BitVector m) (BitVector n) where
   type AResult (BitVector m) (BitVector n) = BitVector (Max m n + 1)
-  plus  = plus#
-  minus = minus#
+  add  = plus#
+  sub = minus#
   type MResult (BitVector m) (BitVector n) = BitVector (m + n)
-  times = times#
+  mul = times#
 
 {-# NOINLINE plus# #-}
 plus# :: (KnownNat m, KnownNat n) => BitVector m -> BitVector n -> BitVector (Max m n + 1)
@@ -836,33 +836,33 @@ decBitVector :: Integer -> TypeQ
 decBitVector n = appT (conT ''BitVector) (litT $ numTyLit n)
 
 instance KnownNat n => SaturatingNum (BitVector n) where
-  satPlus SatWrap a b = a +# b
-  satPlus SatZero a b =
+  satAdd SatWrap a b = a +# b
+  satAdd SatZero a b =
     let r = plus# a b
     in  if msb# r == low
            then resize# r
            else minBound#
-  satPlus _ a b =
+  satAdd _ a b =
     let r  = plus# a b
     in  if msb# r == low
            then resize# r
            else maxBound#
 
-  satMin SatWrap a b = a -# b
-  satMin _ a b =
+  satSub SatWrap a b = a -# b
+  satSub _ a b =
     let r = minus# a b
     in  if msb# r == low
            then resize# r
            else minBound#
 
-  satMult SatWrap a b = a *# b
-  satMult SatZero a b =
+  satMul SatWrap a b = a *# b
+  satMul SatZero a b =
     let r       = times# a b
         (rL,rR) = split# r
     in  case rL of
           0 -> rR
           _ -> minBound#
-  satMult _ a b =
+  satMul _ a b =
     let r       = times# a b
         (rL,rR) = split# r
     in  case rL of

--- a/src/Clash/Sized/Internal/Index.hs
+++ b/src/Clash/Sized/Internal/Index.hs
@@ -242,10 +242,10 @@ fromInteger_INLINE i = bound `seq` if i > (-1) && i < bound then I i else err
 
 instance ExtendingNum (Index m) (Index n) where
   type AResult (Index m) (Index n) = Index (m + n - 1)
-  plus  = plus#
-  minus = minus#
+  add  = plus#
+  sub = minus#
   type MResult (Index m) (Index n) = Index (((m - 1) * (n - 1)) + 1)
-  times = times#
+  mul = times#
 
 plus#, minus# :: Index m -> Index n -> Index (m + n - 1)
 {-# NOINLINE plus# #-}
@@ -264,21 +264,21 @@ times# :: Index m -> Index n -> Index (((m - 1) * (n - 1)) + 1)
 times# (I a) (I b) = I (a * b)
 
 instance (KnownNat n, 1 <= n) => SaturatingNum (Index n) where
-  satPlus SatWrap a b =
+  satAdd SatWrap a b =
     leToPlusKN @1 a $ \a' ->
     leToPlusKN @1 b $ \b' ->
       case plus# a' b' of
         z | let m = fromInteger# (natVal (Proxy @ n))
           , z >= m -> resize# (z - m)
         z -> resize# z
-  satPlus SatZero a b =
+  satAdd SatZero a b =
     leToPlusKN @1 a $ \a' ->
     leToPlusKN @1 b $ \b' ->
       case plus# a' b' of
         z | let m = fromInteger# (natVal (Proxy @ n))
           , z >= m -> fromInteger# 0
         z -> resize# z
-  satPlus _ a b =
+  satAdd _ a b =
     leToPlusKN @1 a $ \a' ->
     leToPlusKN @1 b $ \b' ->
       case plus# a' b' of
@@ -286,31 +286,31 @@ instance (KnownNat n, 1 <= n) => SaturatingNum (Index n) where
           , z >= m -> maxBound#
         z -> resize# z
 
-  satMin SatWrap a b =
+  satSub SatWrap a b =
     if lt# a b
        then maxBound -# (b -# a) +# 1
        else a -# b
 
-  satMin _ a b =
+  satSub _ a b =
     if lt# a b
        then fromInteger# 0
        else a -# b
 
-  satMult SatWrap a b =
+  satMul SatWrap a b =
     leToPlusKN @1 a $ \a' ->
     leToPlusKN @1 b $ \b' ->
       case times# a' b' of
         z | let m = fromInteger# (natVal (Proxy @ n))
           , z >= m -> resize# (z - m)
         z -> resize# z
-  satMult SatZero a b =
+  satMul SatZero a b =
     leToPlusKN @1 a $ \a' ->
     leToPlusKN @1 b $ \b' ->
       case times# a' b' of
         z | let m = fromInteger# (natVal (Proxy @ n))
           , z >= m -> fromInteger# 0
         z -> resize# z
-  satMult _ a b =
+  satMul _ a b =
     leToPlusKN @1 a $ \a' ->
     leToPlusKN @1 b $ \b' ->
       case times# a' b' of

--- a/src/Clash/Sized/Internal/Unsigned.hs
+++ b/src/Clash/Sized/Internal/Unsigned.hs
@@ -125,13 +125,13 @@ import Clash.XException               (ShowX (..), Undefined, showsPrecXWith)
 -- 6
 -- >>> 2 * 4 :: Unsigned 3
 -- 0
--- >>> (2 :: Unsigned 3) `times` (4 :: Unsigned 3) :: Unsigned 6
+-- >>> (2 :: Unsigned 3) `mul` (4 :: Unsigned 3) :: Unsigned 6
 -- 8
--- >>> (2 :: Unsigned 3) `plus` (6 :: Unsigned 3) :: Unsigned 4
+-- >>> (2 :: Unsigned 3) `add` (6 :: Unsigned 3) :: Unsigned 4
 -- 8
--- >>> satPlus SatSymmetric 2 6 :: Unsigned 3
+-- >>> satAdd SatSymmetric 2 6 :: Unsigned 3
 -- 7
--- >>> satMin SatSymmetric 2 3 :: Unsigned 3
+-- >>> satSub SatSymmetric 2 3 :: Unsigned 3
 -- 0
 newtype Unsigned (n :: Nat) =
     -- | The constructor, 'U', and the field, 'unsafeToInteger', are not
@@ -282,10 +282,10 @@ fromInteger_INLINE i = U (i `mod` sz)
 
 instance (KnownNat m, KnownNat n) => ExtendingNum (Unsigned m) (Unsigned n) where
   type AResult (Unsigned m) (Unsigned n) = Unsigned (Max m n + 1)
-  plus  = plus#
-  minus = minus#
+  add  = plus#
+  sub = minus#
   type MResult (Unsigned m) (Unsigned n) = Unsigned (m + n)
-  times = times#
+  mul = times#
 
 {-# NOINLINE plus# #-}
 plus# :: Unsigned m -> Unsigned n -> Unsigned (Max m n + 1)
@@ -426,33 +426,33 @@ decUnsigned :: Integer -> TypeQ
 decUnsigned n = appT (conT ''Unsigned) (litT $ numTyLit n)
 
 instance KnownNat n => SaturatingNum (Unsigned n) where
-  satPlus SatWrap a b = a +# b
-  satPlus SatZero a b =
+  satAdd SatWrap a b = a +# b
+  satAdd SatZero a b =
     let r = plus# a b
     in  case msb r of
           0 -> resize# r
           _ -> minBound#
-  satPlus _ a b =
+  satAdd _ a b =
     let r  = plus# a b
     in  case msb r of
           0 -> resize# r
           _ -> maxBound#
 
-  satMin SatWrap a b = a -# b
-  satMin _ a b =
+  satSub SatWrap a b = a -# b
+  satSub _ a b =
     let r = minus# a b
     in  case msb r of
           0 -> resize# r
           _ -> minBound#
 
-  satMult SatWrap a b = a *# b
-  satMult SatZero a b =
+  satMul SatWrap a b = a *# b
+  satMul SatZero a b =
     let r       = times# a b
         (rL,rR) = split r
     in  case rL of
           0 -> unpack# rR
           _ -> minBound#
-  satMult _ a b =
+  satMul _ a b =
     let r       = times# a b
         (rL,rR) = split r
     in  case rL of

--- a/src/Clash/Sized/RTree.hs
+++ b/src/Clash/Sized/RTree.hs
@@ -97,7 +97,7 @@ import Clash.XException
 let populationCount' :: (KnownNat k, KnownNat (2^k)) => BitVector (2^k) -> Index ((2^k)+1)
     populationCount' bv = tdfold (Proxy @IIndex)
                                  fromIntegral
-                                 (\_ x y -> plus x y)
+                                 (\_ x y -> add x y)
                                  (v2t (bv2v bv))
 :}
 -}
@@ -254,15 +254,15 @@ instance (KnownNat d, Undefined a) => Undefined (RTree d a) where
 -- 'Index' ((2^d)+1) -> 'Index' ((2^d)+1) -> 'Index' ((2^(d+1))+1)
 -- @
 --
--- We have such an adder in the form of the 'Clash.Class.Num.plus' function, as
+-- We have such an adder in the form of the 'Clash.Class.Num.add' function, as
 -- defined in the instance 'Clash.Class.Num.ExtendingNum' instance of 'Index'.
 -- However, we cannot simply use 'fold' to create a tree-structure of
--- 'Clash.Class.Num.plus'es:
+-- 'Clash.Class.Num.add'es:
 --
 -- >>> :{
 -- let populationCount' :: (KnownNat (2^d), KnownNat d, KnownNat (2^d+1))
 --                      => BitVector (2^d) -> Index (2^d+1)
---     populationCount' = tfold fromIntegral plus . v2t . bv2v
+--     populationCount' = tfold fromIntegral add . v2t . bv2v
 -- :}
 -- <BLANKLINE>
 -- <interactive>:...
@@ -273,9 +273,9 @@ instance (KnownNat d, Undefined a) => Undefined (RTree d a) where
 --         Actual type: Index ((2 ^ d) + 1)
 --                      -> Index ((2 ^ d) + 1)
 --                      -> AResult (Index ((2 ^ d) + 1)) (Index ((2 ^ d) + 1))
---     • In the second argument of ‘tfold’, namely ‘plus’
---       In the first argument of ‘(.)’, namely ‘tfold fromIntegral plus’
---       In the expression: tfold fromIntegral plus . v2t . bv2v
+--     • In the second argument of ‘tfold’, namely ‘add’
+--       In the first argument of ‘(.)’, namely ‘tfold fromIntegral add’
+--       In the expression: tfold fromIntegral add . v2t . bv2v
 --     • Relevant bindings include
 --         populationCount' :: BitVector (2 ^ d) -> Index ((2 ^ d) + 1)
 --           (bound at ...)
@@ -283,7 +283,7 @@ instance (KnownNat d, Undefined a) => Undefined (RTree d a) where
 -- because 'tfold' expects a function of type \"@b -> b -> b@\", i.e. a function
 -- where the arguments and result all have exactly the same type.
 --
--- In order to accommodate the type of our 'Clash.Class.Num.plus', where the
+-- In order to accommodate the type of our 'Clash.Class.Num.add', where the
 -- result is larger than the arguments, we must use a dependently typed fold in
 -- the form of 'dtfold':
 --
@@ -299,7 +299,7 @@ instance (KnownNat d, Undefined a) => Undefined (RTree d a) where
 --                  => BitVector (2^k) -> Index ((2^k)+1)
 -- populationCount' bv = 'tdfold' (Proxy @IIndex)
 --                              fromIntegral
---                              (\\_ x y -> 'Clash.Class.Num.plus' x y)
+--                              (\\_ x y -> 'Clash.Class.Num.add' x y)
 --                              ('v2t' ('Clash.Sized.Vector.bv2v' bv))
 -- @
 --

--- a/src/Clash/Sized/Vector.hs
+++ b/src/Clash/Sized/Vector.hs
@@ -185,7 +185,7 @@ let sortV_flip xs = map fst sorted :< (snd (last sorted))
 let populationCount' :: (KnownNat k, KnownNat (2^k)) => BitVector (2^k) -> Index ((2^k)+1)
     populationCount' bv = dtfold (Proxy @IIndex)
                                  fromIntegral
-                                 (\_ x y -> plus x y)
+                                 (\_ x y -> add x y)
                                  (bv2v bv)
 :}
 
@@ -1932,15 +1932,15 @@ dfold _ f z xs = go (snatProxy (asNatProxy xs)) xs
 -- 'Index' ((2^d)+1) -> 'Index' ((2^d)+1) -> 'Index' ((2^(d+1))+1)
 -- @
 --
--- We have such an adder in the form of the 'Clash.Class.Num.plus' function, as
+-- We have such an adder in the form of the 'Clash.Class.Num.add' function, as
 -- defined in the instance 'Clash.Class.Num.ExtendingNum' instance of 'Index'.
 -- However, we cannot simply use 'fold' to create a tree-structure of
--- 'Clash.Class.Num.plus'es:
+-- 'Clash.Class.Num.add'es:
 --
 -- >>> :{
 -- let populationCount' :: (KnownNat (n+1), KnownNat (n+2))
 --                      => BitVector (n+1) -> Index (n+2)
---     populationCount' = fold plus . map fromIntegral . bv2v
+--     populationCount' = fold add . map fromIntegral . bv2v
 -- :}
 -- <BLANKLINE>
 -- <interactive>:...
@@ -1948,9 +1948,9 @@ dfold _ f z xs = go (snatProxy (asNatProxy xs)) xs
 --       Expected type: Index (n + 2) -> Index (n + 2) -> Index (n + 2)
 --         Actual type: Index (n + 2)
 --                      -> Index (n + 2) -> AResult (Index (n + 2)) (Index (n + 2))
---     • In the first argument of ‘fold’, namely ‘plus’
---       In the first argument of ‘(.)’, namely ‘fold plus’
---       In the expression: fold plus . map fromIntegral . bv2v
+--     • In the first argument of ‘fold’, namely ‘add’
+--       In the first argument of ‘(.)’, namely ‘fold add’
+--       In the expression: fold add . map fromIntegral . bv2v
 --     • Relevant bindings include
 --         populationCount' :: BitVector (n + 1) -> Index (n + 2)
 --           (bound at ...)
@@ -1958,7 +1958,7 @@ dfold _ f z xs = go (snatProxy (asNatProxy xs)) xs
 -- because 'fold' expects a function of type \"@a -> a -> a@\", i.e. a function
 -- where the arguments and result all have exactly the same type.
 --
--- In order to accommodate the type of our 'Clash.Class.Num.plus', where the
+-- In order to accommodate the type of our 'Clash.Class.Num.add', where the
 -- result is larger than the arguments, we must use a dependently typed fold in
 -- the form of 'dtfold':
 --
@@ -1974,7 +1974,7 @@ dfold _ f z xs = go (snatProxy (asNatProxy xs)) xs
 --                  => BitVector (2^k) -> Index ((2^k)+1)
 -- populationCount' bv = 'dtfold' (Proxy @IIndex)
 --                              fromIntegral
---                              (\\_ x y -> 'Clash.Class.Num.plus' x y)
+--                              (\\_ x y -> 'Clash.Class.Num.add' x y)
 --                              ('bv2v' bv)
 -- @
 --


### PR DESCRIPTION
Perform the changes in issue #132 :

- sat{Plus, Min, Mult} to sat{Add, Sub, Mul}
- bounded{Plus, Min, Mult} to bounded{Add, Sub, Mul}
- ExtendingNum plus, minus, times to add, sub, mul

This passes clash-prelude unittests and doctests, but appropriate changes also need to be made to clash-compiler, clash-lib and clash-ghc. 